### PR TITLE
DRT-4453 Make queues configurable by terminal

### DIFF
--- a/client/src/main/scala/spatutorial/client/SPAMain.scala
+++ b/client/src/main/scala/spatutorial/client/SPAMain.scala
@@ -33,7 +33,10 @@ object TableViewUtils {
   val fasttrack: QueueName = "fastTrack"
   val egate: QueueName = "eGate"
 
-  def queueNameMappingOrder = eeadesk :: noneeadesk :: /*fasttrack ::*/ egate :: Nil
+  /**
+    * Fixme: remove this line once we've removed the old terminal page
+    */
+  def queueNameMappingOrder = eeadesk :: noneeadesk :: egate :: Nil
 
   def queueDisplayName = Map(eeadesk -> "EEA", noneeadesk -> "Non-EEA", egate -> "e-Gates", fasttrack -> "Fast Track")
 
@@ -166,7 +169,6 @@ object TableViewUtils {
                                queueCrunchResultsForTerminal: QueueCrunchResults,
                                userDeskRec: QueueStaffDeployments, qn: QueueName
                               ): Seq[List[Long]] = {
-    //    log.info(s"queueNosFromCrunchResult: userDeskRecs: ${userDeskRec(qn).get.items.map(_.deskRec.toLong).grouped(15).map(_.max).toList}")
     val ts = DeskRecsChart.takeEvery15th(timestamps).take(numberOf15MinuteSlots).toList
     val userDeskRecsSample: List[Long] = getSafeUserDeskRecs(userDeskRec, qn, ts)
 

--- a/client/src/main/scala/spatutorial/client/SPAMain.scala
+++ b/client/src/main/scala/spatutorial/client/SPAMain.scala
@@ -30,43 +30,50 @@ object TableViewUtils {
 
   val eeadesk: QueueName = "eeaDesk"
   val noneeadesk: QueueName = "nonEeaDesk"
+  val fasttrack: QueueName = "fastTrack"
   val egate: QueueName = "eGate"
 
-  def queueNameMappingOrder = eeadesk :: noneeadesk :: egate :: Nil
+  def queueNameMappingOrder = eeadesk :: noneeadesk :: /*fasttrack ::*/ egate :: Nil
 
-  def queueDisplayName = Map(eeadesk -> "EEA", noneeadesk -> "Non-EEA", egate -> "e-Gates")
+  def queueDisplayName = Map(eeadesk -> "EEA", noneeadesk -> "Non-EEA", egate -> "e-Gates", fasttrack -> "Fast Track")
 
   def terminalDeploymentsRows(
-                                timestamps: Seq[Long],
-                                paxload: Map[String, List[Double]],
-                                queueCrunchResultsForTerminal: Map[QueueName, Pot[PotCrunchResult]],
-                                simulationResult: Map[QueueName, Pot[SimulationResult]],
-                                userDeskRec: QueueStaffDeployments
-                              ): List[TerminalDeploymentsRow] = {
-    log.info(s"call terminalUserDeskRecsRows")
-    val queueRows: List[List[((Long, QueueName), QueueDeploymentsRow)]] = queueNameMappingOrder.map(queueName => {
-      simulationResult.get(queueName) match {
-        case Some(Ready(sr)) =>
-          val result = queueNosFromSimulationResult(timestamps, paxload, queueCrunchResultsForTerminal, userDeskRec, simulationResult, queueName)
-          log.info(s"before transpose it is ${result}")
-          log.info(s"before transpose it is ${result.map(_.length)}")
-          queueDeploymentsRowsFromNos(queueName, result)
-        case None =>
-          queueCrunchResultsForTerminal.get(queueName) match {
-            case Some(Ready(cr)) =>
-              queueDeploymentsRowsFromNos(queueName, queueNosFromCrunchResult(timestamps, paxload, queueCrunchResultsForTerminal, userDeskRec, queueName))
-            case _ =>
-              List()
+                               terminalName: TerminalName,
+                               airportConfigPot: Pot[AirportConfig],
+                               timestamps: Seq[Long],
+                               paxload: Map[String, List[Double]],
+                               queueCrunchResultsForTerminal: Map[QueueName, Pot[PotCrunchResult]],
+                               simulationResult: Map[QueueName, Pot[SimulationResult]],
+                               userDeskRec: QueueStaffDeployments
+                             ): List[TerminalDeploymentsRow] = {
+    airportConfigPot match {
+      case Ready(airportConfig) =>
+        log.info(s"call terminalUserDeskRecsRows")
+        val queueRows: List[List[((Long, QueueName), QueueDeploymentsRow)]] = airportConfig.queues(terminalName).map(queueName => {
+          simulationResult.get(queueName) match {
+            case Some(Ready(sr)) =>
+              val result = queueNosFromSimulationResult(timestamps, paxload, queueCrunchResultsForTerminal, userDeskRec, simulationResult, queueName)
+              log.info(s"before transpose it is ${result}")
+              log.info(s"before transpose it is ${result.map(_.length)}")
+              queueDeploymentsRowsFromNos(queueName, result)
+            case None =>
+              queueCrunchResultsForTerminal.get(queueName) match {
+                case Some(Ready(cr)) =>
+                  queueDeploymentsRowsFromNos(queueName, queueNosFromCrunchResult(timestamps, paxload, queueCrunchResultsForTerminal, userDeskRec, queueName))
+                case _ =>
+                  List()
+              }
           }
-      }
-    })
+        }).toList
 
-    val queueRowsByTime = queueRows.flatten.groupBy(tqr => tqr._1._1)
+        val queueRowsByTime = queueRows.flatten.groupBy(tqr => tqr._1._1)
 
-    queueRowsByTime.map((queueRows: (Long, List[((Long, QueueName), QueueDeploymentsRow)])) => {
-      val qr = queueRows._2.map(_._2)
-      TerminalDeploymentsRow(queueRows._1, qr)
-    }).toList.sortWith(_.time < _.time)
+        queueRowsByTime.map((queueRows: (Long, List[((Long, QueueName), QueueDeploymentsRow)])) => {
+          val qr = queueRows._2.map(_._2)
+          TerminalDeploymentsRow(queueRows._1, qr)
+        }).toList.sortWith(_.time < _.time)
+      case _ => List()
+    }
   }
 
   def terminalUserDeskRecsRows(
@@ -159,7 +166,7 @@ object TableViewUtils {
                                queueCrunchResultsForTerminal: QueueCrunchResults,
                                userDeskRec: QueueStaffDeployments, qn: QueueName
                               ): Seq[List[Long]] = {
-//    log.info(s"queueNosFromCrunchResult: userDeskRecs: ${userDeskRec(qn).get.items.map(_.deskRec.toLong).grouped(15).map(_.max).toList}")
+    //    log.info(s"queueNosFromCrunchResult: userDeskRecs: ${userDeskRec(qn).get.items.map(_.deskRec.toLong).grouped(15).map(_.max).toList}")
     val ts = DeskRecsChart.takeEvery15th(timestamps).take(numberOf15MinuteSlots).toList
     val userDeskRecsSample: List[Long] = getSafeUserDeskRecs(userDeskRec, qn, ts)
 
@@ -201,6 +208,7 @@ object SPAMain extends js.JSApp {
   case class TerminalUserDeskRecommendationsLoc(terminalName: TerminalName) extends Loc
 
   case class TerminalRecsLoc(id: String) extends Loc
+
   case class TerminalDepsLoc(id: String) extends Loc
 
   case object StaffingLoc extends Loc
@@ -218,17 +226,6 @@ object SPAMain extends js.JSApp {
   // configure the router
   val routerConfig = RouterConfigDsl[Loc].buildConfig { dsl =>
     import dsl._
-    val dashboardModelsConnect = SPACircuit.connect(m =>
-      DashboardModels(m.workload, m.queueCrunchResults, m.simulationResult))
-    val airportConfigPotRCP: ReactConnectProxy[Pot[AirportConfig]] = SPACircuit.connect(_.airportConfig)
-
-    val dashboardRoute = staticRoute("#charts", DashboardLoc) ~>
-      renderR(ctl => dashboardModelsConnect(proxy => {
-        log.info("charts update")
-        airportConfigPotRCP(airportConfigPotMP =>
-          Dashboard(ctl, proxy, airportConfigPotMP())
-        )
-      }))
 
     val rootRoute = staticRoute(root, FlightsLoc) ~>
       renderR(ctl => {
@@ -244,25 +241,15 @@ object SPAMain extends js.JSApp {
         airportWrapper(airportInfoProxy => flightsWrapper(proxy => FlightsView(Props(proxy.value, airportInfoProxy.value))))
       })
 
-
-    val terminalRecs = dynamicRouteCT("#terminal-recs" / string("[a-zA-Z0-9]+")
-      .caseClass[TerminalRecsLoc]) ~> dynRenderR((page: TerminalRecsLoc, ctl) => TerminalRecsPage(page.id, ctl))
     val terminalDeps = dynamicRouteCT("#terminal-deps" / string("[a-zA-Z0-9]+")
       .caseClass[TerminalDepsLoc]) ~> dynRenderR((page: TerminalDepsLoc, ctl) => TerminalDepsPage(page.id, ctl))
-
-    val userDeskRecsRoute = staticRoute("#userdeskrecs", UserDeskRecommendationsLoc) ~> renderR(ctl => {
-      //todo take the queuenames from the workloads response
-      log.info("running our user desk recs route")
-
-      QueueUserDeskRecsComponent.terminalQueueUserDeskRecsComponent()
-    })
 
     val staffing = staticRoute("#staffing", StaffingLoc) ~>
       renderR(ctl => {
         Staffing()
       })
 
-    val rule = rootRoute | dashboardRoute | flightsRoute | userDeskRecsRoute | terminalRecs | terminalDeps | staffing
+    val rule = rootRoute | flightsRoute | terminalDeps | staffing
     rule.notFound(redirectToPage(DashboardLoc)(Redirect.Replace))
   }.renderWith(layout)
 

--- a/client/src/main/scala/spatutorial/client/components/Heatmap.scala
+++ b/client/src/main/scala/spatutorial/client/components/Heatmap.scala
@@ -29,11 +29,7 @@ object TerminalHeatmaps {
           val maxAcrossAllSeries = heatMapSeries.map(x => emptySafeMax(x.data)).max
           log.info(s"Got max workload of ${maxAcrossAllSeries}")
           <.div(
-            Heatmap.heatmap(Heatmap.Props(
-              series = heatMapSeries,
-              height = 200,
-              scaleFunction = Heatmap.bucketScale(maxAcrossAllSeries)
-            ))
+            Heatmap.heatmap(Heatmap.Props(series = heatMapSeries, scaleFunction = Heatmap.bucketScale(maxAcrossAllSeries)))
           )
         }))
     })
@@ -59,8 +55,7 @@ object TerminalHeatmaps {
           val maxAcrossAllSeries = emptySafeMax(queueSeries.map(x => x.data.max))
           log.info(s"Got max waittime of ${maxAcrossAllSeries}")
           <.div(
-            Heatmap.heatmap(Heatmap.Props(series = queueSeries, height = 200,
-              scaleFunction = Heatmap.bucketScale(maxAcrossAllSeries)))
+            Heatmap.heatmap(Heatmap.Props(series = queueSeries, scaleFunction = Heatmap.bucketScale(maxAcrossAllSeries)))
           )
         }))
     })
@@ -75,7 +70,7 @@ object TerminalHeatmaps {
     }.toList)
     seriiRCP((serMP: ModelProxy[List[Series]]) => {
       <.div(
-        Heatmap.heatmap(Heatmap.Props(series = serMP(), height = 200, scaleFunction = Heatmap.bucketScale(20)))
+        Heatmap.heatmap(Heatmap.Props(series = serMP(), scaleFunction = Heatmap.bucketScale(20)))
       )
     })
   }
@@ -98,9 +93,7 @@ object TerminalHeatmaps {
               seriesPot.renderReady(series => {
                 val maxRatioAcrossAllSeries = emptySafeMax(series.map(_.data.max)) + 1
                 <.div(
-                  Heatmap.heatmap(Heatmap.Props(series = series, height = 200,
-                    scaleFunction = Heatmap.bucketScale(maxRatioAcrossAllSeries),
-                    valueDisplayFormatter = v => f"${v}%.1f")))
+                  Heatmap.heatmap(Heatmap.Props(series = series, scaleFunction = Heatmap.bucketScale(maxRatioAcrossAllSeries), valueDisplayFormatter = v => f"${v}%.1f")))
               }))
           })
         )
@@ -170,12 +163,9 @@ object Heatmap {
 
   case class Series(name: String, data: IndexedSeq[Double])
 
-  case class Props(width: Int = 960, height: Int, numberOfBlocks: Int = 24,
-                   series: Seq[Series],
-                   scaleFunction: (Double) => Int,
-                   shouldShowRectValue: Boolean = true,
-                   valueDisplayFormatter: (Double) => String = _.toInt.toString
-                  )
+  case class Props(width: Int = 960, numberOfBlocks: Int = 24, series: Seq[Series], scaleFunction: (Double) => Int, shouldShowRectValue: Boolean = true, valueDisplayFormatter: (Double) => String = _.toInt.toString) {
+    def height = 50 * (series.length + 1)
+  }
 
   val colors = Vector("#D3F8E6", "#BEF4CC", "#A9F1AB", "#A8EE96", "#B2EA82", "#C3E76F", "#DCE45D",
     "#E0C54B", "#DD983A", "#DA6429", "#D72A18")

--- a/client/src/main/scala/spatutorial/client/components/MainMenu.scala
+++ b/client/src/main/scala/spatutorial/client/components/MainMenu.scala
@@ -35,26 +35,15 @@ object MainMenu {
 
   val staticMenuItems = List(
     MenuItem(1, _ => "Flights", Icon.plane, FlightsLoc),
-    MenuItem(2, buildTodoMenu, Icon.calculator, UserDeskRecommendationsLoc),
-    MenuItem(3, _ => "Charts", Icon.dashboard, DashboardLoc),
-    MenuItem(4, _ => "Staffing", Icon.dashboard, StaffingLoc)
+    MenuItem(2, _ => "Staffing", Icon.dashboard, StaffingLoc)
   )
 
   def menuItems(airportConfigPotMP: ModelProxy[Pot[AirportConfig]]) = {
-    val terminalRecsMenuItems = airportConfigPotMP().state match {
-      case PotReady =>
-        airportConfigPotMP().get.terminalNames.zipWithIndex.map {
-          case (tn, idx) =>
-            MenuItem(idx + staticMenuItems.length + 1, _ => tn, Icon.calculator, TerminalRecsLoc(tn))
-        }.toList
-      case _ =>
-        List()
-    }
     val terminalDepsMenuItems = airportConfigPotMP().state match {
       case PotReady =>
         airportConfigPotMP().get.terminalNames.zipWithIndex.map {
           case (tn, idx) =>
-            MenuItem(idx + staticMenuItems.length + terminalRecsMenuItems.length + 1, _ => tn, Icon.calculator, TerminalDepsLoc(tn))
+            MenuItem(idx + staticMenuItems.length + 1, _ => tn, Icon.calculator, TerminalDepsLoc(tn))
         }.toList
       case _ =>
         List()

--- a/client/src/main/scala/spatutorial/client/components/QueueUserDeskRecs.scala
+++ b/client/src/main/scala/spatutorial/client/components/QueueUserDeskRecs.scala
@@ -78,7 +78,7 @@ object QueueUserDeskRecsComponent {
         airportConfigPotMP().renderPending(_ => "Hello pending"),
         airportConfigPotMP().renderReady((airportConfig: AirportConfig) => {
           val queueUserDeskRecProps: Seq[QueueUserDeskRecsComponent.Props] = airportConfig.terminalNames.flatMap { terminalName =>
-            airportConfig.queues.map { queueName =>
+            airportConfig.queues(terminalName).map { queueName =>
               val labelsPotRCP = SPACircuit.connect(_.workload.map(_.labels))
               val crunchResultPotRCP = SPACircuit.connect(_.queueCrunchResults.getOrElse(terminalName, Map()).getOrElse(queueName, Empty).flatten)
               val userDeskRecsPotRCP = SPACircuit.connect(_.staffDeploymentsByTerminalAndQueue.getOrElse(terminalName, Map()).getOrElse(queueName, Empty))

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -55,7 +55,7 @@ table.user-desk-recs > tbody > tr > td.date-field {
   text-align: left;
 }
 
-table.user-desk-recs {
+table.user-desk-recs.cols-2, table.user-desk-recs.cols-3, table.user-desk-recs.cols-4 {
   thead th:nth-child(1) {
     width: 180px;
   }
@@ -65,10 +65,44 @@ table.user-desk-recs {
   }
 }
 
+table.user-desk-recs.cols-4 {
+  thead th:nth-last-child(-n+2) {
+    width: 66px;
+  }
 
+  tbody td:nth-last-child(-n+2) {
+    width: 66px;
+  }
+}
 
-table.user-desk-recs tbody td, table.user-desk-recs thead th {
+table.user-desk-recs.cols-3 {
+  thead th:nth-last-child(1) {
+    width: 88px;
+  }
+
+  tbody td:nth-last-child(1) {
+    width: 88px;
+  }
+
+  thead th:nth-last-child(2) {
+    width: 89px;
+  }
+
+  tbody td:nth-last-child(2) {
+    width: 89px;
+  }
+}
+
+table.user-desk-recs.cols-4 tbody td, table.user-desk-recs.cols-4 thead th {
+  width: 69px;
+}
+
+table.user-desk-recs.cols-3 tbody td, table.user-desk-recs.cols-3 thead th {
   width: 87px;
+}
+
+table.user-desk-recs.cols-2 tbody td, table.user-desk-recs.cols-2 thead th {
+  width: 120px;
 }
 
 table.user-desk-recs > tbody > tr > td > input:focus {
@@ -259,8 +293,7 @@ p {
 
 .terminal-desk-recs-container {
   height: 800px;
-  width: 1152px;
-  //overflow: scroll;
+  width: 1155px;
 }
 
 .user-desk-recs-container {

--- a/server/src/main/scala/actors/CrunchActor.scala
+++ b/server/src/main/scala/actors/CrunchActor.scala
@@ -120,7 +120,10 @@ abstract class CrunchActor(crunchPeriodHours: Int,
   }
 
   def reCrunchAllTerminalsAndQueues(): Unit = {
-    for (tn <- airportConfig.terminalNames; qn <- airportConfig.queues) {
+    for {
+      tn <- airportConfig.terminalNames;
+      qn <- airportConfig.queues(tn)
+    } {
       val crunch: Future[CrunchResult] = performCrunch(tn, qn)
       crunch.onSuccess {
         case crunchResult =>

--- a/server/src/test/scala/services/EGateBanksTests.scala
+++ b/server/src/test/scala/services/EGateBanksTests.scala
@@ -91,7 +91,7 @@ object EGateBanksTests extends TestSuite {
       val eGateBanks = List(1)
 
       val airportConfig = AirportConfig(
-        queues = Seq(),
+        queues = Map(),
         slaByQueue = Map("eeaDesk" -> 5),
         terminalNames = Seq(),
         defaultPaxSplits = List(),
@@ -119,7 +119,7 @@ object EGateBanksTests extends TestSuite {
       val eGateBanks = List(1)
 
       val airportConfig = AirportConfig(
-        queues = Seq(),
+        queues = Map(),
         slaByQueue = Map("eGate" -> 5),
         terminalNames = Seq(),
         defaultPaxSplits = List(),

--- a/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
+++ b/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
@@ -62,7 +62,7 @@ object CrunchTests {
         Map(
           PaxTypeAndQueue(PaxTypes.eeaMachineReadable, Queues.eeaDesk) -> 20d / 60,
           PaxTypeAndQueue(PaxTypes.eeaMachineReadable, Queues.eGate) -> 25d / 60)),
-    queues = Seq("eeaDesk", "eGate"),
+    queues = Map("A1" -> Seq("eeaDesk", "eGate")),
     portCode = "EDI",
     slaByQueue = Map("eeaDesk" -> 25, "eGate" -> 5),
     terminalNames = Seq("A1")

--- a/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
@@ -9,6 +9,7 @@ object Queues {
   val eeaDesk = "eeaDesk"
   val eGate = "eGate"
   val nonEeaDesk = "nonEeaDesk"
+  val fastTrack = "fastTrack"
 }
 
 sealed trait PaxType {
@@ -33,7 +34,7 @@ case class SplitRatio(paxType: PaxTypeAndQueue, ratio: Double)
 
 case class AirportConfig(
                           portCode: String = "n/a",
-                          queues: Seq[QueueName],
+                          queues: Map[TerminalName, Seq[QueueName]],
                           slaByQueue: Map[String, Int],
                           terminalNames: Seq[TerminalName],
                           defaultPaxSplits: List[SplitRatio],
@@ -49,7 +50,7 @@ trait HasAirportConfig {
 trait AirportConfigLike {
   def portCode: String
 
-  def queues: Seq[QueueName]
+  def queues: Map[TerminalName, Seq[QueueName]]
 
   def slaByQueue: Map[String, Int]
 
@@ -79,7 +80,10 @@ object AirportConfigs {
 
   val edi = AirportConfig(
     portCode = "EDI",
-    queues = Seq("eeaDesk", "eGate", "nonEeaDesk"),
+    queues = Map(
+      "A1" -> Seq("eeaDesk", "eGate", "nonEeaDesk"),
+      "A2" -> Seq("eeaDesk", "eGate", "nonEeaDesk")
+    ),
     slaByQueue = defaultSlas,
     terminalNames = Seq("A1", "A2"),
     defaultPaxSplits = defaultPaxSplits,
@@ -101,8 +105,10 @@ object AirportConfigs {
   )
   val stn = AirportConfig(
     portCode = "STN",
-    queues = Seq("eeaDesk", "eGate", "nonEeaDesk"),
-    slaByQueue = Map("eeaDesk" -> 25, "eGate" -> 5, "nonEeaDesk" -> 45),
+    queues = Map(
+      "T1" -> Seq("eeaDesk", "eGate", "nonEeaDesk")
+    ),
+    slaByQueue = Map("eeaDesk" -> 25, "eGate" -> 5,"nonEeaDesk" -> 45),
     terminalNames = Seq("T1"),
     defaultPaxSplits = List(
       SplitRatio(PaxTypeAndQueue(PaxTypes.eeaMachineReadable, Queues.eeaDesk), 0.4875),
@@ -121,7 +127,11 @@ object AirportConfigs {
   )
   val man = AirportConfig(
     portCode = "MAN",
-    queues = Seq("eeaDesk", "eGate", "nonEeaDesk"),
+    queues = Map(
+      "T1" -> Seq("eeaDesk", "eGate", "nonEeaDesk"),
+      "T2" -> Seq("eeaDesk", "eGate", "nonEeaDesk"),
+      "T3" -> Seq("eeaDesk", "eGate", "nonEeaDesk")
+    ),
     slaByQueue = Map("eeaDesk" -> 25, "eGate" -> 10, "nonEeaDesk" -> 45),
     terminalNames = Seq("T1", "T2", "T3"),
     defaultPaxSplits = defaultPaxSplits,
@@ -129,7 +139,9 @@ object AirportConfigs {
   )
   val ltn = AirportConfig(
     portCode = "LTN",
-    queues = Seq("eeaDesk", "eGate", "nonEeaDesk"),
+    queues = Map(
+      "T1" -> Seq("eeaDesk", "eGate", "nonEeaDesk")
+    ),
     slaByQueue = defaultSlas,
     terminalNames = Seq("T1"),
     defaultPaxSplits = defaultPaxSplits,


### PR DESCRIPTION
Drive front end from airport config queue definitions rather than a hard coded list of queues
Style terminal page to account for 2, 3 & 4 queue terminals