### PR TITLE
DRT-4583 Always use Localtime in JS

### DIFF
--- a/client/src/main/scala/spatutorial/client/services/StaffAssignmentParser.scala
+++ b/client/src/main/scala/spatutorial/client/services/StaffAssignmentParser.scala
@@ -52,11 +52,9 @@ object JSDateConversions {
       def millisSinceEpoch: Long = date.getTime().toLong
     }
 
-    def asUTCDate(d: Date): Date = new Date(d.getTime() - (d.getTimezoneOffset() * 60000))
-
     def apply(milliDate: MilliDate): SDateLike = new Date(milliDate.millisSinceEpoch)
 
-    def apply(y: Int, m: Int, d: Int, h: Int = 0, mm: Int = 0): SDateLike = asUTCDate(new Date(y, m - 1, d, h, mm))
+    def apply(y: Int, m: Int, d: Int, h: Int = 0, mm: Int = 0): SDateLike = new Date(y, m - 1, d, h, mm)
 
     def parse(dateString: String): SDateLike = new Date(dateString)
 
@@ -65,7 +63,7 @@ object JSDateConversions {
       d.setHours(0)
       d.setMinutes(0)
       d.setMilliseconds(0)
-      JSSDate(asUTCDate(d))
+      JSSDate(d)
     }
 
     def now(): SDateLike = {

--- a/client/src/test/scala/spatutorial/client/services/SDateTests.scala
+++ b/client/src/test/scala/spatutorial/client/services/SDateTests.scala
@@ -52,10 +52,10 @@ object SDateTests extends TestSuite {
       }
 
       "During BST" - {
-        "should take dates as UTC but return as local time with day, month, date, time constructor" - {
+        "should take dates as UTC and return millis since epoch as UTC" - {
           val d = SDate(2017, 3, 28, 14, 44)
-          val actual = d.toString
-          assert(actual == "2017-03-28T1544")
+          val actual = d.millisSinceEpoch
+          assert(actual == 1490708640000L)
         }
         "should take dates as UTC but return as local time with millisecond constructor" - {
           val d = SDate(MilliDate(1490708453000L)) //2017-03-28 13:40 GMT


### PR DESCRIPTION
 - Change JSSDate to always work in local time
 - Using millisSinceEpoch will always return UTC time