### PR TITLE
Drt 4602 transfer passengers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,8 @@ import sbt.Project.projectToRef
 
 scalaVersion := Settings.versions.scala
 
-enablePlugins(net.virtualvoid.optimizer.SbtOptimizerPlugin)
+// uncomment the following to get a breakdown  of where build time is spent
+//enablePlugins(net.virtualvoid.optimizer.SbtOptimizerPlugin)
 
 // a special crossProject for configuring a JS/JVM/shared structure
 lazy val shared = (crossProject.crossType(CrossType.Pure) in file("shared"))

--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -2,7 +2,7 @@ package drt.client
 
 import diode.data.{Pot, Ready}
 import drt.client.actions.Actions._
-import drt.client.components.TerminalDeploymentsTable.{QueueDeploymentsRow, QueueDeploymentsRowEntry, TerminalDeploymentsRow}
+import drt.client.components.TerminalDeploymentsTable.{QueueDeploymentsRow, QueueDeploymentsRowEntry, QueuePaxRowEntry, TerminalDeploymentsRow}
 import drt.client.components.{GlobalStyles, Layout, Staffing, TerminalPage, TerminalsDashboardPage}
 import drt.client.logger._
 import drt.client.services.HandyStuff.{PotCrunchResult, QueueStaffDeployments}
@@ -63,15 +63,15 @@ object TableViewUtils {
     }
   }
 
-  def processTransfers(timestamps: Seq[Long], paxload: Map[String, List[Double]]): List[((Long, QueueName), QueueDeploymentsRow)] = {
+  def processTransfers(timestamps: Seq[Long], queuePaxload: Map[String, List[Double]]): List[((Long, QueueName), QueueDeploymentsRow)] = {
     log.info(s"processing transfers rows")
     val sampledTs = sampleTimestampsForRows(timestamps)
-    log.info(s"looking for paxload in ${paxload.keys}")
-    val sampledPaxload = samplePaxLoad(paxload, Queues.Transfer)
+    log.info(s"looking for paxload in ${queuePaxload.keys}")
+    val sampledPaxload = samplePaxLoad(queuePaxload, Queues.Transfer)
     log.info(s"sampled paxload")
     val zippedTsAndPaxload = sampledTs.zip(sampledPaxload)
     val res = zippedTsAndPaxload.map {
-      case (ts, paxload) => (ts, Queues.Transfer) -> QueueDeploymentsRowEntry(ts, paxload, 0, DeskRecTimeslot(ts, 0), 0, 0, Queues.Transfer)
+      case (ts, paxLoad) => (ts, Queues.Transfer) -> QueuePaxRowEntry(ts, Queues.Transfer, paxLoad)
     }
     log.info(s"returning transfers rows")
     res

--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -23,17 +23,15 @@ import scalacss.Defaults._
 
 object TableViewUtils {
 
-  val eeadesk: QueueName = "eeaDesk"
-  val noneeadesk: QueueName = "nonEeaDesk"
-  val fasttrack: QueueName = "fastTrack"
-  val egate: QueueName = "eGate"
 
   /**
     * Fixme: remove this line once we've removed the old terminal page
     */
-  def queueNameMappingOrder = eeadesk :: noneeadesk :: egate :: Nil
+  def queueNameMappingOrder = Queues.EeaDesk :: Queues.NonEeaDesk :: Queues.EGate :: Nil
 
-  val queueDisplayNames = Map(eeadesk -> "EEA", noneeadesk -> "Non-EEA", egate -> "e-Gates", fasttrack -> "Fast Track")
+  val queueDisplayNames = Map(Queues.EeaDesk -> "EEA", Queues.NonEeaDesk -> "Non-EEA", Queues.EGate -> "e-Gates",
+    Queues.FastTrack -> "Fast Track",
+    Queues.Transfer -> "Tran")
 
   def queueDisplayName(name: String) = queueDisplayNames.getOrElse(name, name)
 

--- a/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
+++ b/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
@@ -107,7 +107,8 @@ object BigSummaryBoxes {
       <.h3(
         nbsp,
         <.span(
-          <.div(^.className := "split-graph-container splitsource-" + source,
+          // summary-box-count best-pax-count are here as a dirty hack for alignment with the other boxes
+          <.div(^.className := "summary-box-count best-pax-count split-graph-container splitsource-" + source,
             splitsGraphComponentColoure(splitTotal, orderedSplitCounts), sourceDisplay))
       )
     }
@@ -120,7 +121,8 @@ object BigSummaryBoxes {
 
   val SummaryBox = ScalaComponent.builder[Props]("SummaryBox")
     .render_P((p) => {
-      <.div(^.className := "summary-boxes",
+
+      <.div(^.className := "summary-boxes ",
         <.div(^.className := "summary-box-container", <.h3(<.span(^.className := "summary-box-count flight-count", f"${p.flightCount}%,d "), <.span(^.className := "sub", "Flights"))),
         <.div(^.className := "summary-box-container", <.h3(<.span(^.className := "summary-box-count best-pax-count", f"${p.bestPaxCount}%,d "), <.span(^.className := "sub", "Best Pax"))),
         <.div(^.className := "summary-box-container", GraphComponent("aggregated", "pax", "", p.aggSplits.values.sum, p.aggSplits)))

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -84,16 +84,12 @@ object FlightsWithSplitsTable {
         else
           <.div("No flights in this time period")
       } match {
-        case Success(s) =>
-          log.info(s"table rendered!!")
-          s
-
+        case Success(s) => s
         case Failure(f) =>
           log.error(s"failure in table render $f")
           <.div(s"render failure ${f}")
       }
     })
-    .componentDidMount((props) => Callback.log(s"componentDidMount! $props"))
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -24,13 +24,13 @@ object FlightsWithSplitsTable {
   implicit val paxTypeReuse = Reusability.byRef[PaxType]
   implicit val doubleReuse = Reusability.double(0.001)
   implicit val splitStyleReuse = Reusability.byRef[SplitStyle]
-  implicit val paxtypeandQueueReuse = Reusability.caseClassDebug[ApiPaxTypeAndQueueCount]
-  implicit val SplitsReuse = Reusability.caseClassDebug[ApiSplits]
-  implicit val flightReuse = Reusability.caseClassDebug[Arrival]
-  implicit val apiflightsWithSplitsReuse = Reusability.caseClassDebug[ApiFlightWithSplits]
-  implicit val flightsWithSplitsReuse = Reusability.caseClassDebug[FlightsWithSplits]
+  implicit val paxtypeandQueueReuse = Reusability.caseClass[ApiPaxTypeAndQueueCount]
+  implicit val SplitsReuse = Reusability.caseClass[ApiSplits]
+  implicit val flightReuse = Reusability.caseClass[Arrival]
+  implicit val apiflightsWithSplitsReuse = Reusability.caseClass[ApiFlightWithSplits]
+  implicit val flightsWithSplitsReuse = Reusability.caseClass[FlightsWithSplits]
   implicit val bestPaxReuse = Reusability.byRefOr_==[BestPaxForArrivalF]
-  implicit val propsReuse = Reusability.caseClassDebug[Props]
+  implicit val propsReuse = Reusability.caseClass[Props]
 
   def ArrivalsTable[C](timelineComponent: Option[(Arrival) => VdomNode] = None,
                        originMapper: (String) => VdomNode = (portCode) => portCode,
@@ -113,17 +113,17 @@ object FlightTableRow {
   implicit val splitStyleReuse = Reusability.byRef[SplitStyle]
   implicit val paxTypeReuse = Reusability.byRef[PaxType]
   implicit val doubleReuse = Reusability.double(0.01)
-  implicit val paxtypeandQueueReuse = Reusability.caseClassDebug[ApiPaxTypeAndQueueCount]
-  //  implicit val flightReuse = Reusability.caseClassDebug[List[ApiPaxTypeAndQueueCount]]
-  //  implicit val flightReuse = Reusability.caseClassDebug[List[Arrival]]
-  implicit val SplitsReuse = Reusability.caseClassDebug[ApiSplits]
-  implicit val flightReuse = Reusability.caseClassDebug[Arrival]
-  implicit val apiflightsWithSplitsReuse = Reusability.caseClassDebug[ApiFlightWithSplits]
-  implicit val flightsWithSplitsReuse = Reusability.caseClassDebug[FlightsWithSplits]
+  implicit val paxtypeandQueueReuse = Reusability.caseClass[ApiPaxTypeAndQueueCount]
+  //  implicit val flightReuse = Reusability.caseClass[List[ApiPaxTypeAndQueueCount]]
+  //  implicit val flightReuse = Reusability.caseClass[List[Arrival]]
+  implicit val SplitsReuse = Reusability.caseClass[ApiSplits]
+  implicit val flightReuse = Reusability.caseClass[Arrival]
+  implicit val apiflightsWithSplitsReuse = Reusability.caseClass[ApiFlightWithSplits]
+  implicit val flightsWithSplitsReuse = Reusability.caseClass[FlightsWithSplits]
 
   implicit val originMapperReuse = Reusability.byRefOr_==[OriginMapperF]
   implicit val arrivalToPax = Reusability.byRefOr_==[BestPaxForArrivalF]
-  implicit val propsReuse = Reusability.caseClassExceptDebug[Props]('timelineComponent, 'paxComponent, 'splitsGraphComponent)
+  implicit val propsReuse = Reusability.caseClassExcept[Props]('timelineComponent, 'paxComponent, 'splitsGraphComponent)
 
   case class RowState(hasChanged: Boolean)
 

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -39,13 +39,10 @@ object FlightsWithSplitsTable {
                       ) = ScalaComponent.builder[Props]("ArrivalsTable")
 
     .renderP((_$, props) => {
-      log.info(s"sorting flights")
       val flightsWithSplits = props.flightsWithSplits
       val bestPax = props.bestPax
       val flightsWithCodeShares: Seq[(ApiFlightWithSplits, Set[Arrival])] = FlightTableComponents.uniqueArrivalsWithCodeShares(flightsWithSplits.flights)
-
       val sortedFlights = flightsWithCodeShares.sortBy(_._1.apiFlight.SchDT) //todo move this closer to the model
-      log.info(s"sorted flights")
       val isTimeLineSupplied = timelineComponent.isDefined
       val timelineTh = (if (isTimeLineSupplied) <.th("Timeline") :: Nil else List[TagMod]()).toTagMod
       Try {

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -147,7 +147,7 @@ object FlightTableRow {
       val flight = flightWithSplits.apiFlight
       val allCodes = flight.ICAO :: codeShares.map(_.ICAO).toList
 
-      log.info(s"rendering flight row $idx ${flight.toString}")
+      log.debug(s"rendering flight row $idx ${flight.toString}")
       Try {
         val flightSplitsList: List[ApiSplits] = flightWithSplits.splits
 
@@ -241,7 +241,6 @@ object FlightTableRow {
         log.info(s"row ${i.nextProps} changed")
       i.setState(RowState(i.nextProps != i.currentProps))
     })
-    .componentDidMount(p => Callback.log(s"row didMount $p"))
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/client/src/main/scala/drt/client/components/Heatmap.scala
+++ b/client/src/main/scala/drt/client/components/Heatmap.scala
@@ -177,8 +177,8 @@ object TerminalHeatmaps {
 
   def waitTimes(simulationResult: Map[QueueName, Pot[SimulationResult]], terminalName: String): Pot[List[Series]] = {
     val result: Iterable[Series] = for {
-      queueName <- simulationResult.keys
-      simResult <- simulationResult(queueName)
+      (queueName, simResultPot) <- simulationResult
+      simResult <- simResultPot
       waitTimes = simResult.waitTimes
     } yield {
       Series(terminalName + "/" + queueName,

--- a/client/src/main/scala/drt/client/components/Heatmap.scala
+++ b/client/src/main/scala/drt/client/components/Heatmap.scala
@@ -40,6 +40,26 @@ object TerminalHeatmaps {
         }))
     })
   }
+  def heatmapOfPaxloads(terminalName: TerminalName) = {
+    val workloadsRCP = SPACircuit.connect(_.workloadPot)
+    workloadsRCP((workloadsMP: ModelProxy[Pot[Workloads]]) => {
+      <.div(
+        workloadsMP().renderReady(wl => {
+          wl.workloads.get(terminalName) match {
+            case Some(terminalWorkload) =>
+              val heatMapSeries = paxloads(terminalWorkload, terminalName)
+              val maxAcrossAllSeries = heatMapSeries.map(x => emptySafeMax(x.data)).max
+              log.info(s"Got max paxLoad of ${maxAcrossAllSeries}")
+              log.info(s"heatmap terminalWorkloas ${terminalWorkload.keys}")
+              <.div(
+                Heatmap.heatmap(Heatmap.Props(series = heatMapSeries.sortBy(_.name), scaleFunction = Heatmap.bucketScale(maxAcrossAllSeries)))
+              )
+            case None =>
+              <.div(s"No paxloads for ${terminalName}")
+          }
+        }))
+    })
+  }
 
   def emptySafeMax(data: Seq[Double]): Double = {
     data match {
@@ -122,10 +142,12 @@ object TerminalHeatmaps {
     })
   }
 
-  def chartDataFromWorkloads(workloads: Map[String, QueuePaxAndWorkLoads], minutesPerGroup: Int = 15): Map[String, List[Double]] = {
+  def chartDataFromWorkloads(workloads: Map[String, (Seq[WL], Seq[Pax])], minutesPerGroup: Int = 15,
+                             paxloadWorkloadSelector: ((Seq[WL], Seq[Pax])) => Map[Long, Double]): Map[String, List[Double]] = {
     val startFromMilli = WorkloadsHelpers.midnightBeforeNow()
     val minutesRangeInMillis: NumericRange[Long] = WorkloadsHelpers.minutesForPeriod(startFromMilli, 24)
-    val queueWorkloadsByMinute = WorkloadsHelpers.workloadPeriodByQueue(workloads, minutesRangeInMillis)
+//    val queueWorkloadsByMinute = WorkloadsHelpers.workloadPeriodByQueue(workloads, minutesRangeInMillis)
+    val queueWorkloadsByMinute =  WorkloadsHelpers.loadPeriodByQueue(workloads, minutesRangeInMillis, paxloadWorkloadSelector)
     val by15Minutes = queueWorkloadsByMinute.mapValues(
       (v) => v.grouped(minutesPerGroup).map(_.sum).toList
     )
@@ -134,7 +156,17 @@ object TerminalHeatmaps {
 
   def workloads(terminalWorkloads: Map[QueueName, (Seq[WL], Seq[Pax])], terminalName: String): List[Series] = {
     log.info(s"!!!!looking up $terminalName in wls")
-    val queueWorkloads: Predef.Map[String, List[Double]] = chartDataFromWorkloads(terminalWorkloads, 60)
+    val queueWorkloads: Predef.Map[String, List[Double]] = chartDataFromWorkloads(terminalWorkloads, 60, WorkloadsHelpers.workloadByMillis)
+    val result: Iterable[Series] = for {
+      (queue, work) <- queueWorkloads
+    } yield {
+      Series(terminalName + "/" + queue, work.toVector)
+    }
+    result.toList
+  }
+  def paxloads(terminalWorkloads: Map[QueueName, (Seq[WL], Seq[Pax])], terminalName: String): List[Series] = {
+    log.info(s"!!!!looking up $terminalName in wls")
+    val queueWorkloads: Predef.Map[String, List[Double]] = chartDataFromWorkloads(terminalWorkloads, 60, WorkloadsHelpers.paxloadByMillis)
     val result: Iterable[Series] = for {
       (queue, work) <- queueWorkloads
     } yield {
@@ -234,7 +266,6 @@ object Heatmap {
     ).build
 
   def getRects(serie: Series, numberofblocks: Int, gridSize: Int, props: Props, sIndex: Int): TagOf[G] = {
-    log.info(s"Rendering rects for $serie")
     Try {
       val rects = serie.data.zipWithIndex.map {
         case (periodValue, idx) => {

--- a/client/src/main/scala/drt/client/components/Navbar.scala
+++ b/client/src/main/scala/drt/client/components/Navbar.scala
@@ -19,7 +19,11 @@ object Navbar {
               <.span(^.className := "navbar-brand", s"DRT ${airportConfig.portCode} Live"),
               <.div(^.className := "collapse navbar-collapse", MainMenu(ctl, page),
                 <.ul(^.className := "nav navbar-nav navbar-right",
-                  <.li(StaffMovementsPopover(airportConfig.terminalNames, page, "IS81", "IS81", SDate.now(), SDate.now().addHours(1), "bottom")()))))
+                  <.li(StaffMovementsPopover(airportConfig.terminalNames, page, "Staff movements", "Reason...", SDate.now(), SDate.now().addHours(1), "bottom")()),
+                  <.li(StaffMovementsPopover(airportConfig.terminalNames, page, "Breaks+15", "Breaks", SDate.now(), SDate.now().addMinutes(15), "bottom")()),
+                  <.li(StaffMovementsPopover(airportConfig.terminalNames, page, "Breaks+30", "Breaks", SDate.now(), SDate.now().addMinutes(30), "bottom")()),
+                  <.li(StaffMovementsPopover(airportConfig.terminalNames, page, "Breaks+45", "Breaks", SDate.now(), SDate.now().addMinutes(45), "bottom")())
+                )))
 
           }))
       })

--- a/client/src/main/scala/drt/client/components/TerminalDeploymentsTable.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDeploymentsTable.scala
@@ -126,8 +126,8 @@ object TerminalDeploymentsTable {
           rowsOptMP() match {
             case None => <.div("No rows yet")
             case Some(rowsPot) =>
-              log.info(s"rowLen ${rowsPot.map(_.length)}")
-              log.info(s"rowsAre $rowsPot")
+              log.debug(s"rowLen ${rowsPot.map(_.length)}")
+              log.debug(s"rowsAre $rowsPot")
               <.div(
                 rowsPot.renderReady(rows =>
                   airportConfigPotRCP(airportConfigPotMP => {
@@ -192,7 +192,7 @@ object TerminalDeploymentsTable {
       case _ => ""
     }
     val queueRowCellsWithTotal: List[html_<^.TagMod] = (queueRowCells :+
-      <.td(^.className := s"totl-deployed $ragClass", totalRequired) :+
+      <.td(^.className := s"total-deployed $ragClass", totalRequired) :+
       <.td(^.className := s"total-deployed $ragClass", totalDeployed)).toList
     <.tr(<.td(^.cls := "date-field", airportInfoPopover()) :: queueRowCellsWithTotal: _*)
   }

--- a/client/src/main/scala/drt/client/components/TerminalDeploymentsTable.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDeploymentsTable.scala
@@ -161,7 +161,7 @@ object TerminalDeploymentsTable {
     val airportInfo: ReactConnectProxy[Map[String, Pot[AirportInfo]]] = props.airportInfos
     val airportInfoPopover = FlightsPopover(formattedDate, flights, airportInfo)
 
-    val queueRowCells: Seq[TagMod] = item.queueDetails.flatMap {
+    val queueRowCells: Seq[TagMod] = item.queueDetails.collect {
       case (q: QueueDeploymentsRowEntry) => {
         val warningClasses = if (q.waitTimeWithCrunchDeskRec < q.waitTimeWithUserDeskRec) "table-warning" else ""
         val dangerWait = if (q.waitTimeWithUserDeskRec > props.airportConfig.slaByQueue.getOrElse(q.queueName, 0)) "table-danger" else ""
@@ -174,11 +174,15 @@ object TerminalDeploymentsTable {
           qtd(^.title := s"Rec: ${q.crunchDeskRec}", q.userDeskRec.deskRec),
           qtd(^.cls := dangerWait + " " + warningClasses, q.waitTimeWithUserDeskRec + " mins"))
       }
+    }.flatten
+
+    val transferCells: TagMod = item.queueDetails.collect {
       case q: QueuePaxRowEntry => {
         def qtd(xs: TagMod*): TagMod = <.td((^.className := queueColour(q.queueName)) :: xs.toList: _*)
+
         Seq(qtd(q.pax))
       }
-    }.toList
+    }.flatten.toTagMod
 
     val staffRequiredQueues: Seq[QueueDeploymentsRowEntry] = item.queueDetails.collect { case q: QueueDeploymentsRowEntry => q }
     val totalRequired: Int = staffRequiredQueues.map(_.crunchDeskRec).sum
@@ -190,7 +194,8 @@ object TerminalDeploymentsTable {
     }
     val queueRowCellsWithTotal: List[html_<^.TagMod] = (queueRowCells :+
       <.td(^.className := s"total-deployed $ragClass", totalRequired) :+
-      <.td(^.className := s"total-deployed $ragClass", totalDeployed)).toList
+      <.td(^.className := s"total-deployed $ragClass", totalDeployed) :+ transferCells
+      ).toList
     <.tr(<.td(^.cls := "date-field", airportInfoPopover()) :: queueRowCellsWithTotal: _*)
   }
 
@@ -200,16 +205,21 @@ object TerminalDeploymentsTable {
 
     def render(props: Props) = {
       val t = Try {
-        log.info("%%%%%%%rendering terminal deployments table...")
+        log.debug("%%%%%%%rendering terminal deployments table...")
 
         val style = bss.listGroup
 
         def qth(queueName: String, xs: TagMod*) = <.th((^.className := queueName + "-user-desk-rec") :: xs.toList: _*)
 
-        val headings = props.airportConfig.queues(props.terminalName).map {
+        val queueHeadings: List[TagMod] = props.airportConfig.queues(props.terminalName).collect{
+          case queueName if queueName != Queues.Transfer => qth(queueName, <.h3(queueDisplayName(queueName)), ^.colSpan := 3)
+        }.toList
+
+        val transferHeading: TagMod = props.airportConfig.queues(props.terminalName).collect{
           case (queueName@Queues.Transfer) => qth(queueName, <.h3(queueDisplayName(queueName)), ^.colSpan := 1)
-          case (queueName) => qth(queueName, <.h3(queueDisplayName(queueName)), ^.colSpan := 3)
-        }.toList :+ <.th(^.className := "total-deployed", ^.colSpan := 2, <.h3("Totals"))
+        }.toList.toTagMod
+
+        val headings: List[TagMod] = queueHeadings :+ <.th(^.className := "total-deployed", ^.colSpan := 2, <.h3("Totals")) :+ transferHeading
 
         val defaultNumberOfQueues = 3
         val headOption = props.items.headOption
@@ -244,14 +254,21 @@ object TerminalDeploymentsTable {
 
     val headerGroupStart = ^.borderLeft := "solid 1px #fff"
 
-    private def subHeadingLevel2(queueNames: List[QueueName]) = {
-      val subHeadingLevel2 = queueNames.flatMap {
+    private def subHeadingLevel2(queueNames: List[QueueName]): List[TagMod] = {
+      val queueSubHeadings: List[TagMod] = queueNames.collect {
+        case queueName if queueName != Queues.Transfer => <.th(^.className := queueColour(queueName), "Pax") :: staffDeploymentSubheadings(queueName)
+      }.flatten
+
+      val transferSubHeadings: TagMod = queueNames.collect {
         case Queues.Transfer => <.th(^.className := queueColour(Queues.Transfer), "Pax") :: Nil
-        case queueName => <.th(^.className := queueColour(queueName), "Pax") :: staffDeploymentSubheadings(queueName)
-      }
-      subHeadingLevel2 :+
+      }.flatten.toTagMod
+
+      val list: List[TagMod] = queueSubHeadings :+
         <.th(^.className := "total-deployed", "Rec", ^.title := "Total staff recommended for desks") :+
-        <.th(^.className := "total-deployed", "Deployed", ^.title := "Total staff deployed based on assignments entered")
+        <.th(^.className := "total-deployed", "Deployed", ^.title := "Total staff deployed based on assignments entered") :+
+        transferSubHeadings
+
+      list
     }
 
     private def thHeaderGroupStart(title: String, xs: TagMod*): VdomTagOf[TableHeaderCell] = {

--- a/client/src/main/scala/drt/client/components/TerminalPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPage.scala
@@ -121,50 +121,53 @@ object TerminalPage {
             val bestPax = BestPax(airportConfig.portCode)
             val terminalProps = TerminalDeploymentsTable.TerminalProps(props.terminalName)
             <.div(
-            <.ul(^.className := "nav nav-tabs",
-              <.li(^.className := "active", <.a(VdomAttr("data-toggle") := "tab", ^.href := "#deskrecs", "Desk recommendations")),
-              <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#workloads", "Workloads")),
-              seriesPot.renderReady(s =>
-                <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#waits", "Wait times"))
+              <.ul(^.className := "nav nav-tabs",
+                <.li(^.className := "active", <.a(VdomAttr("data-toggle") := "tab", ^.href := "#deskrecs", "Desk recommendations")),
+                <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#workloads", "Workloads")),
+                <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#paxloads", "Paxloads")),
+                seriesPot.renderReady(s =>
+                  <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#waits", "Wait times"))
+                )
               )
-            )
-            ,
-            <.div(^.className := "tab-content",
-              <.div(^.id := "deskrecs", ^.className := "tab-pane fade in active",
-                heatmapOfStaffDeploymentDeskRecs(props.terminalName)),
-              <.div(^.id := "workloads", ^.className := "tab-pane fade",
-                heatmapOfWorkloads(props.terminalName)),
-              <.div(^.id := "waits", ^.className := "tab-pane fade",
-                heatmapOfWaittimes(props.terminalName))
-            )
-            ,
-            <.ul(^.className := "nav nav-tabs",
-              <.li(^.className := "active", <.a(VdomAttr("data-toggle") := "tab", ^.href := "#arrivals", "Arrivals")),
-              <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#queues", "Desks & Queues"))
-            )
-            ,
-            <.div(^.className := "tab-content",
-              <.div(^.id := "arrivals", ^.className := "tab-pane fade in active", {
-                val flightsWrapper = SPACircuit.connect(_.flightsWithSplitsPot)
-                flightsWrapper(proxy => {
-                  val flightsWithSplits = proxy.value
-                  val flights: Pot[FlightsApi.FlightsWithSplits] = flightsWithSplits
-                  <.div(flights.renderReady((flightsWithSplits: FlightsWithSplits) => {
-                    val maxFlightPax = flightsWithSplits.flights.map(_.apiFlight.MaxPax).max
-                    val flightsForTerminal = FlightsWithSplits(flightsWithSplits.flights.filter(f => f.apiFlight.Terminal == props.terminalName))
+              ,
+              <.div(^.className := "tab-content",
+                <.div(^.id := "deskrecs", ^.className := "tab-pane fade in active",
+                  heatmapOfStaffDeploymentDeskRecs(props.terminalName)),
+                <.div(^.id := "workloads", ^.className := "tab-pane fade",
+                  heatmapOfWorkloads(props.terminalName)),
+                <.div(^.id := "paxloads", ^.className := "tab-pane fade",
+                  heatmapOfPaxloads(props.terminalName)),
+                <.div(^.id := "waits", ^.className := "tab-pane fade",
+                  heatmapOfWaittimes(props.terminalName))
+              )
+              ,
+              <.ul(^.className := "nav nav-tabs",
+                <.li(^.className := "active", <.a(VdomAttr("data-toggle") := "tab", ^.href := "#arrivals", "Arrivals")),
+                <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#queues", "Desks & Queues"))
+              )
+              ,
+              <.div(^.className := "tab-content",
+                <.div(^.id := "arrivals", ^.className := "tab-pane fade in active", {
+                  val flightsWrapper = SPACircuit.connect(_.flightsWithSplitsPot)
+                  flightsWrapper(proxy => {
+                    val flightsWithSplits = proxy.value
+                    val flights: Pot[FlightsApi.FlightsWithSplits] = flightsWithSplits
+                    <.div(flights.renderReady((flightsWithSplits: FlightsWithSplits) => {
+                      val maxFlightPax = flightsWithSplits.flights.map(_.apiFlight.MaxPax).max
+                      val flightsForTerminal = FlightsWithSplits(flightsWithSplits.flights.filter(f => f.apiFlight.Terminal == props.terminalName))
 
-                    FlightsWithSplitsTable.ArrivalsTable(
-                      timelineComp,
-                      originMapper,
-                      paxComp(maxFlightPax),
-                      splitsGraphComponent)(FlightsWithSplitsTable.Props(flightsForTerminal, bestPax))
-                  }))
-                })
-              }),
-              <.div(^.id := "queues", ^.className := "tab-pane fade terminal-desk-recs-container",
-                TerminalDeploymentsTable.terminalDeploymentsComponent(terminalProps)
-              )
-            ))
+                      FlightsWithSplitsTable.ArrivalsTable(
+                        timelineComp,
+                        originMapper,
+                        paxComp(maxFlightPax),
+                        splitsGraphComponent)(FlightsWithSplitsTable.Props(flightsForTerminal, bestPax))
+                    }))
+                  })
+                }),
+                <.div(^.id := "queues", ^.className := "tab-pane fade terminal-desk-recs-container",
+                  TerminalDeploymentsTable.terminalDeploymentsComponent(terminalProps)
+                )
+              ))
           }))
       })
       <.div(liveSummaryBoxes, simulationResultComponent)

--- a/client/src/main/scala/drt/client/components/TerminalPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPage.scala
@@ -111,7 +111,6 @@ object TerminalPage {
 
       val simulationResultComponent = airportConfigRCP((airportConfigMP: ModelProxy[Pot[AirportConfig]]) => {
         val airportConfigPot = airportConfigMP()
-        val seriesPot: Pot[List[Series]] = waitTimes(simResAndAirportConfigMP()._1.getOrElse(props.terminalName, Map()), props.terminalName)
 
         <.div({
           airportConfigPot.renderReady(airportConfig => {

--- a/client/src/main/scala/drt/client/components/TerminalPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPage.scala
@@ -125,6 +125,7 @@ object TerminalPage {
                       <.ul(^.className := "nav nav-tabs",
                         <.li(^.className := "active", <.a(VdomAttr("data-toggle") := "tab", ^.href := "#deskrecs", "Desk recommendations")),
                         <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#workloads", "Workloads")),
+                        <.li(<.a(VdomAttr("data-toggle") := "tab", ^.href := "#paxloads", "Paxloads")),
                         <.li(seriesPot.renderReady(s => {<.a(VdomAttr("data-toggle") := "tab", ^.href := "#waits", "Wait times")}))
                       )
                       ,

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -145,19 +145,6 @@ case class RootModel(
 
           val paxLoad: Map[String, List[Double]] = WorkloadsHelpers.paxloadPeriodByQueue(terminalWorkloads, minutesRangeInMillis)
 
-          log.debug({
-            val terminalPaxInByQueue = terminalWorkloads.mapValues(_._2.map(_.pax).sum)
-            val queuePaxTotals = paxLoad.mapValues(_.sum)
-            val paxLoadTotal = terminalWorkloads.flatMap(_._2._2.map(_.pax)).sum
-            val start = SDate(MilliDate(startFromMilli))
-            val end = SDate(MilliDate(minutesRangeInMillis.end))
-
-            val earliestAndLatest = terminalWorkloads.mapValues(v =>
-              (SDate(MilliDate(v._2.head.time)), SDate(MilliDate(v._2.last.time)))
-            )
-            s"calculateTerminalDeploymentRows ($start, $end) $terminalName $earliestAndLatest inputTotal: $paxLoadTotal outputTotal: ${queuePaxTotals.values.sum} inputShape: $terminalPaxInByQueue outputShape: $queuePaxTotals"
-          })
-
           TableViewUtils.terminalDeploymentsRows(terminalName, airportConfig, timestamps, paxLoad, crv, srv, udr)
         case None =>
           Nil

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -422,7 +422,7 @@ class FlightsHandler[M](modelRW: ModelRW[M, Pot[FlightsWithSplits]]) extends Log
             })
           }
 
-          val allEffects = airportInfos >> getWorkloads
+          val allEffects = airportInfos // >> getWorkloads
           updated(Ready(flightsWithSplits), allEffects)
         } else {
           log.info("no changes to flights")

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -414,10 +414,13 @@ class FlightsHandler[M](modelRW: ModelRW[M, Pot[FlightsWithSplits]]) extends Log
           val airportCodes = flights.map(_.Origin).toSet
           val airportInfos = Effect(Future(GetAirportInfos(airportCodes)))
 
-//          val getWorkloads = {
-//            //todo - our heatmap updated too frequently right now if we do this, will require some shouldComponentUpdate finesse
-//            Effect.action(log.info("flights Have changed - will re-request workloads")) >> Effect(Future(GetWorkloads("", "")))
-//          }
+          val getWorkloads = {
+            //todo - our heatmap updated too frequently right now if we do this, will require some shouldComponentUpdate finesse
+            Effect(Future {
+              log.info("flights Have changed - re-requesting workloads")
+              GetWorkloads("", "")
+            })
+          }
 
           val allEffects = airportInfos >> getWorkloads
           updated(Ready(flightsWithSplits), allEffects)

--- a/client/src/main/scala/drt/client/services/StaffAssignmentParser.scala
+++ b/client/src/main/scala/drt/client/services/StaffAssignmentParser.scala
@@ -24,6 +24,7 @@ object JSDateConversions {
   implicit def jsDateToSDate(date: Date): SDateLike = JSSDate(date)
 
   object SDate {
+
     case class JSSDate(date: Date) extends SDateLike {
 
       def getFullYear(): Int = date.getFullYear()
@@ -49,6 +50,12 @@ object JSDateConversions {
         newDate
       }
 
+      def addMinutes(minutesToAdd: Int): SDateLike = {
+        val newDate = new Date(millisSinceEpoch)
+        newDate.setMinutes(newDate.getMinutes() + minutesToAdd)
+        newDate
+      }
+
       def millisSinceEpoch: Long = date.getTime().toLong
 
 
@@ -56,12 +63,12 @@ object JSDateConversions {
 
     def apply(milliDate: MilliDate): SDateLike = new Date(milliDate.millisSinceEpoch)
 
-    /****
+    /** **
       * Beware - in JS land, this is interpreted as Local time, but the parse will interpret the timezone component
       */
     def apply(y: Int, m: Int, d: Int, h: Int = 0, mm: Int = 0): SDateLike = new Date(y, m - 1, d, h, mm)
 
-    /***
+    /** *
       * dateString is an ISO parseable datetime representation, with optional timezone
       *
       * @param dateString
@@ -82,6 +89,7 @@ object JSDateConversions {
       JSSDate(d)
     }
   }
+
 }
 
 case class StaffAssignment(name: String, terminalName: TerminalName, startDt: MilliDate, endDt: MilliDate, numberOfStaff: Int) {
@@ -156,6 +164,7 @@ case class StaffAssignmentParser(rawStaffAssignments: String) {
 case class StaffAssignmentService(assignments: Seq[StaffAssignment]) {
   def staffAt(date: MilliDate): Int = assignments.filter(assignment =>
     assignment.startDt <= date && date <= assignment.endDt).map(_.numberOfStaff).sum
+
   def terminalStaffAt(terminalName: TerminalName, date: MilliDate): Int = assignments.filter(assignment => {
     assignment.startDt <= date && date <= assignment.endDt && assignment.terminalName == terminalName
   }).map(_.numberOfStaff).sum

--- a/client/src/test/scala/drt/client/services/TerminalDeploymentTests.scala
+++ b/client/src/test/scala/drt/client/services/TerminalDeploymentTests.scala
@@ -1,7 +1,7 @@
 package drt.client.services
 
 import diode.data._
-import drt.client.components.TerminalDeploymentsTable.{QueueDeploymentsRow, TerminalDeploymentsRow}
+import drt.client.components.TerminalDeploymentsTable.{QueueDeploymentsRowEntry, TerminalDeploymentsRow}
 import drt.shared.SplitRatiosNs.{SplitRatio, SplitRatios}
 import drt.shared._
 import utest._
@@ -47,7 +47,7 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), Seq(0L), workload, queueCrunchResults, simulationResult, Map())
 
       val expected = Seq(TerminalDeploymentsRow(0L, Seq(
-        QueueDeploymentsRow(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"))))
+        QueueDeploymentsRowEntry(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"))))
 
       assert(expected == result)
     }
@@ -69,8 +69,8 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), Seq(0L), workload, queueCrunchResults, simulationResult, Map())
 
       val expected = Seq(TerminalDeploymentsRow(0L, Seq(
-        QueueDeploymentsRow(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"),
-        QueueDeploymentsRow(0, pax = 6, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eGate")
+        QueueDeploymentsRowEntry(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"),
+        QueueDeploymentsRowEntry(0, pax = 6, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eGate")
       )))
 
       assert(expected == result)
@@ -99,9 +99,9 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), Seq(0L), workload, queueCrunchResults, simulationResult, Map())
 
       val expected = Seq(TerminalDeploymentsRow(0L, Seq(
-        QueueDeploymentsRow(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"),
-        QueueDeploymentsRow(0, pax = 6, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "nonEeaDesk"),
-        QueueDeploymentsRow(0, pax = 7, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eGate")
+        QueueDeploymentsRowEntry(0, pax = 5, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "eeaDesk"),
+        QueueDeploymentsRowEntry(0, pax = 6, crunchDeskRec = 1, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 10, waitTimeWithUserDeskRec = 5, "nonEeaDesk"),
+        QueueDeploymentsRowEntry(0, pax = 7, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eGate")
       )))
 
       assert(expected == result)
@@ -122,7 +122,7 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), List(0L, 60000L), workload, queueCrunchResults, simulationResult, Map())
 
       val expected = List(TerminalDeploymentsRow(0L, Seq(
-        QueueDeploymentsRow(0, pax = 5, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eeaDesk")
+        QueueDeploymentsRowEntry(0, pax = 5, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eeaDesk")
       )))
 
       assert(expected == result)
@@ -151,9 +151,9 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), List(0L, 60000L), workload, queueCrunchResults, simulationResult, Map())
 
       val expected = Seq(TerminalDeploymentsRow(0L, Seq(
-        QueueDeploymentsRow(0, pax = 6, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eeaDesk"),
-        QueueDeploymentsRow(0, pax = 8, crunchDeskRec = 21, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 34, waitTimeWithUserDeskRec = 30, "nonEeaDesk"),
-        QueueDeploymentsRow(0, pax = 7, crunchDeskRec = 23, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 27, waitTimeWithUserDeskRec = 25, "eGate")
+        QueueDeploymentsRowEntry(0, pax = 6, crunchDeskRec = 2, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 20, waitTimeWithUserDeskRec = 10, "eeaDesk"),
+        QueueDeploymentsRowEntry(0, pax = 8, crunchDeskRec = 21, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 34, waitTimeWithUserDeskRec = 30, "nonEeaDesk"),
+        QueueDeploymentsRowEntry(0, pax = 7, crunchDeskRec = 23, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 27, waitTimeWithUserDeskRec = 25, "eGate")
       )))
 
       assert(expected == result)
@@ -184,8 +184,8 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), timestamps, workload, queueCrunchResults, simulationResult, userDeskRec = Map())
 
       val expected = Seq(
-        TerminalDeploymentsRow(0L, Seq(QueueDeploymentsRow(0L, pax = 75, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"))),
-        TerminalDeploymentsRow(15L * 60000, Seq(QueueDeploymentsRow(15L * 60000, pax = 5, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk")))
+        TerminalDeploymentsRow(0L, Seq(QueueDeploymentsRowEntry(0L, pax = 75, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"))),
+        TerminalDeploymentsRow(15L * 60000, Seq(QueueDeploymentsRowEntry(15L * 60000, pax = 5, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk")))
       )
 
       assert(expected == result)
@@ -242,9 +242,9 @@ object TerminalDeploymentTests extends TestSuite  {
       val result = terminalDeploymentsRows("T1", Ready(airportConfig), timestamps, workload, queueCrunchResults, simulationResult, Map())
 
       val expected = Seq(
-        TerminalDeploymentsRow(0L, Seq(QueueDeploymentsRow(0L, pax = 71, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"))),
-        TerminalDeploymentsRow(15L * 60000, Seq(QueueDeploymentsRow(15L * 60000, pax = 76, crunchDeskRec = 9, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 9, waitTimeWithUserDeskRec = 14, "eeaDesk"))),
-        TerminalDeploymentsRow(30L * 60000, Seq(QueueDeploymentsRow(30L * 60000, pax = 12, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(30L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk")))
+        TerminalDeploymentsRow(0L, Seq(QueueDeploymentsRowEntry(0L, pax = 71, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"))),
+        TerminalDeploymentsRow(15L * 60000, Seq(QueueDeploymentsRowEntry(15L * 60000, pax = 76, crunchDeskRec = 9, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 9, waitTimeWithUserDeskRec = 14, "eeaDesk"))),
+        TerminalDeploymentsRow(30L * 60000, Seq(QueueDeploymentsRowEntry(30L * 60000, pax = 12, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(30L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk")))
       )
 
       assert(expected == result)
@@ -307,11 +307,11 @@ object TerminalDeploymentTests extends TestSuite  {
 
       val expected = Seq(
         TerminalDeploymentsRow(0L, Seq(
-          QueueDeploymentsRow(0L, pax = 71, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"),
-          QueueDeploymentsRow(0L, pax = 72, crunchDeskRec = 8, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 9, waitTimeWithUserDeskRec = 16, "nonEeaDesk"))),
+          QueueDeploymentsRowEntry(0L, pax = 71, crunchDeskRec = 7, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 8, waitTimeWithUserDeskRec = 15, "eeaDesk"),
+          QueueDeploymentsRowEntry(0L, pax = 72, crunchDeskRec = 8, userDeskRec = DeskRecTimeslot(0, 0), waitTimeWithCrunchDeskRec = 9, waitTimeWithUserDeskRec = 16, "nonEeaDesk"))),
         TerminalDeploymentsRow(15L * 60000, Seq(
-          QueueDeploymentsRow(15L * 60000, pax = 9, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk"),
-          QueueDeploymentsRow(15L * 60000, pax = 11, crunchDeskRec = 4, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 5, waitTimeWithUserDeskRec = 10, "nonEeaDesk")
+          QueueDeploymentsRowEntry(15L * 60000, pax = 9, crunchDeskRec = 3, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 4, waitTimeWithUserDeskRec = 9, "eeaDesk"),
+          QueueDeploymentsRowEntry(15L * 60000, pax = 11, crunchDeskRec = 4, userDeskRec = DeskRecTimeslot(15L * 60000, 0), waitTimeWithCrunchDeskRec = 5, waitTimeWithUserDeskRec = 10, "nonEeaDesk")
         ))
       )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -95,6 +95,7 @@ object Settings {
     "com.mfglabs" %% "commons-aws" % "0.10.0",
     "org.apache.commons" % "commons-csv" % "1.4",
     "com.vmunier" %% "scalajs-scripts" % "1.0.0",
+    "com.lihaoyi" %% "pprint" % "0.4.3",
     "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
 
   "joda-time" % "joda-time" % "2.9.4") :::
@@ -116,6 +117,7 @@ object Settings {
     //    "com.payalabs" %%% "scalajs-react-bridge" % "0.2.0-SNAPSHOT",
     "io.suzaku" %%% "diode-react" % versions.diode,
     "org.scala-js" %%% "scalajs-dom" % versions.scalaDom,
+    "com.lihaoyi" %%% "pprint" % "0.4.3",
     "com.lihaoyi" %%% "utest" % versions.uTest % Test
   ))
 

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -282,10 +282,12 @@ tr:nth-child(odd) > td.eeaDesk-user-desk-rec.table-info {
 
 .transfer-user-desk-rec {
   background-color: @transferUserDeskColor;
+  color: #ffffff;
 }
 
 tr:nth-child(even) > td.transfer-user-desk-rec{
   background-color: lighten(@transferUserDeskColor, 5%);
+  color: #ffffff;
 }
 
 tr:nth-child(odd) > td.nonEeaDesk-user-desk-rec {

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -117,7 +117,7 @@ table.user-desk-recs > tbody > tr > td.date-field {
   text-align: left;
 }
 
-table.user-desk-recs.cols-2, table.user-desk-recs.cols-3, table.user-desk-recs.cols-4 {
+table.user-desk-recs.cols-2, table.user-desk-recs.cols-3, table.user-desk-recs.cols-4, table.user-desk-recs.cols-5 {
   thead th:nth-child(1) {
     width: 180px;
   }
@@ -126,6 +126,17 @@ table.user-desk-recs.cols-2, table.user-desk-recs.cols-3, table.user-desk-recs.c
     width: 180px;
   }
 }
+
+table.user-desk-recs.cols-5 {
+  thead th:nth-last-child(-n+2) {
+    width: 66px;
+  }
+
+  tbody td:nth-last-child(-n+2) {
+    width: 66px;
+  }
+}
+
 
 table.user-desk-recs.cols-4 {
   thead th:nth-last-child(-n+2) {
@@ -136,6 +147,7 @@ table.user-desk-recs.cols-4 {
     width: 66px;
   }
 }
+
 
 table.user-desk-recs.cols-3 {
   thead th:nth-last-child(1) {
@@ -153,6 +165,10 @@ table.user-desk-recs.cols-3 {
   tbody td:nth-last-child(2) {
     width: 89px;
   }
+}
+
+table.user-desk-recs.cols-5 tbody td, table.user-desk-recs.cols-5 thead th {
+  width: 69px;
 }
 
 table.user-desk-recs.cols-4 tbody td, table.user-desk-recs.cols-4 thead th {

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -223,6 +223,7 @@ rect.bordered {
 @nonEeaDeskUserDeskColor: #cce0d6;
 @eGateUserDeskColor: #f7f0e2;
 @fastTrackUserDeskColor: #e7cee6;
+@transferUserDeskColor: #8F23B3; // this is from the BF style guidelines, the HAL transfer colour, and the BF colour, are coincidentally very similar
 @totalDeployedColor: #eeeff0;
 @amberColor: #FFEEBB;
 @redColor: #FFCCCC;
@@ -277,6 +278,14 @@ tr:nth-child(odd) > td.eeaDesk-user-desk-rec.table-info {
 
 .fastTrack-user-desk-rec {
   background-color: @fastTrackUserDeskColor;
+}
+
+.transfer-user-desk-rec {
+  background-color: @transferUserDeskColor;
+}
+
+tr:nth-child(even) > td.transfer-user-desk-rec{
+  background-color: lighten(@transferUserDeskColor, 5%);
 }
 
 tr:nth-child(odd) > td.nonEeaDesk-user-desk-rec {
@@ -510,12 +519,12 @@ th h2 {
 }
 
 .splits .graph .bar.eeaDesk {
-  background-color: orange;
+  background-color: deepskyblue;
 
 }
 
 .splits .graph .bar.eGate {
-  background-color: deepskyblue;
+  background-color: orange;
 }
 
 .splits .graph .bar.nonEeaDesk {

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -128,11 +128,11 @@ table.user-desk-recs.cols-2, table.user-desk-recs.cols-3, table.user-desk-recs.c
 }
 
 table.user-desk-recs.cols-5 {
-  thead th:nth-last-child(-n+2) {
+  thead th:nth-last-child(-n+3) {
     width: 66px;
   }
 
-  tbody td:nth-last-child(-n+2) {
+  tbody td:nth-last-child(-n+3) {
     width: 66px;
   }
 }
@@ -239,7 +239,7 @@ rect.bordered {
 @nonEeaDeskUserDeskColor: #cce0d6;
 @eGateUserDeskColor: #f7f0e2;
 @fastTrackUserDeskColor: #e7cee6;
-@transferUserDeskColor: #8F23B3; // this is from the BF style guidelines, the HAL transfer colour, and the BF colour, are coincidentally very similar
+@transferUserDeskColor: #705975;
 @totalDeployedColor: #eeeff0;
 @amberColor: #FFEEBB;
 @redColor: #FFCCCC;

--- a/server/src/main/assets/stylesheets/popover-styles-staff-movement.less
+++ b/server/src/main/assets/stylesheets/popover-styles-staff-movement.less
@@ -41,7 +41,7 @@
   -ms-user-select: none;
   user-select: none;
   color: #fff;
-  background-color: rgb(215, 42, 24);
+  background-color: rgb(129, 162, 215);
   border-color: #2e6da4;
 }
 .popover.staff-movement-popover .popover__content::before {

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
 
     <!--<logger name="services.AdvPaxSplitsProvider" level="DEBUG" />-->
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -10,7 +10,10 @@
 
     <!--<logger name="services.AdvPaxSplitsProvider" level="DEBUG" />-->
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
+    <logger level="DEBUG" name="services">
+        <appender-ref ref="STDOUT"/>
+    </logger>
 </configuration>

--- a/server/src/main/scala/actors/CrunchActor.scala
+++ b/server/src/main/scala/actors/CrunchActor.scala
@@ -140,12 +140,6 @@ abstract class CrunchActor(crunchPeriodHours: Int,
       qn <- airportConfig.queues(tn).filterNot(_ == Queues.Transfer)
     } {
       val crunch: Future[CrunchResult] = performCrunch(tn, qn)
-      //      crunchCache.get(cacheKey(tn, qn)) match {
-      //        case None => crunchCache(cacheKey(tn, qn)) {
-      //          crunch
-      //        }
-      //        case _ =>
-      //      }
       crunch.onSuccess {
         case crunchResult =>
           self ! SaveCrunchResult(tn, qn, crunchResult)

--- a/server/src/main/scala/passengersplits/core/PassengerInfoRouterActor.scala
+++ b/server/src/main/scala/passengersplits/core/PassengerInfoRouterActor.scala
@@ -70,6 +70,7 @@ class PassengerSplitsInfoByPortRouter extends
   Actor with PassengerQueueCalculator with ActorLogging
   with SimpleRouterActor[PassengerInfoRouterActor] {
 
+  var latestFileName: Option[String] = None
   def childProps = Props[PassengerInfoRouterActor]
 
   def receive: PartialFunction[Any, Unit] = LoggingReceive {
@@ -99,9 +100,10 @@ class PassengerSplitsInfoByPortRouter extends
       log.info(s"top level router asked to ${report}")
       val child = getRCActor(childName(report.destinationPort))
       child.tell(report, sender)
-    case VoyageManifestZipFileComplete(zipfilename, completionMonitor) =>
+    case VoyageManifestZipFileComplete(zipFilename, completionMonitor) =>
       log.info(s"FlightPaxSplitBatchComplete received telling $completionMonitor")
-      completionMonitor ! VoyageManifestZipFileCompleteAck(zipfilename)
+      latestFileName = Some(zipFilename)
+      completionMonitor ! VoyageManifestZipFileCompleteAck(zipFilename)
     case report: ReportFlightCode =>
       childActorMap.values.foreach(_.tell(report, sender))
     case LogStatus =>
@@ -162,6 +164,11 @@ class SingleFlightActor
   override def postRestart(reason: Throwable): Unit = {
     log.info(s"SingleFlightActor restarting ${self} ")
     super.postRestart(reason)
+  }
+
+  override def postStop(): Unit = {
+    log.info(s"SingleFlightActor for ${latestMessage.map(_.summary)} stopped")
+    super.postStop()
   }
 
   def receive = LoggingReceive {

--- a/server/src/main/scala/passengersplits/core/PassengerTypeCalculator.scala
+++ b/server/src/main/scala/passengersplits/core/PassengerTypeCalculator.scala
@@ -59,9 +59,11 @@ trait PassengerQueueCalculator {
 }
 
 object PassengerQueueCalculator extends PassengerQueueCalculator {
+  val log = LoggerFactory.getLogger(getClass)
   def convertPassengerInfoToPaxQueueCounts(ps: Seq[PassengerInfoJson], egatePercentage: Double): PassengerQueueTypes.PaxTypeAndQueueCounts = {
     val paxTypes = PassengerTypeCalculator.paxTypes(ps)
     val paxTypeCounts = countPassengerTypes(paxTypes)
+    log.info(s"paxTypes: $paxTypeCounts")
     val queuePaxCounts = calculateQueuePaxCounts(paxTypeCounts, egatePercentage)
     queuePaxCounts
   }

--- a/server/src/main/scala/passengersplits/core/PassengerTypeCalculator.scala
+++ b/server/src/main/scala/passengersplits/core/PassengerTypeCalculator.scala
@@ -5,7 +5,7 @@ import passengersplits.parsing.VoyageManifestParser.PassengerInfoJson
 import drt.shared.{PassengerQueueTypes, PaxType}
 import drt.shared.PassengerQueueTypes.PaxTypeAndQueueCounts
 import drt.shared.PassengerSplits.SplitsPaxTypeAndQueueCount
-import drt.shared.PaxTypes.{EeaMachineReadable, EeaNonMachineReadable, NonVisaNational, VisaNational}
+import drt.shared.PaxTypes._
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Iterable
@@ -32,10 +32,12 @@ trait PassengerQueueCalculator {
       case (EeaNonMachineReadable, paxCount) =>
         Seq(SplitsPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, paxCount))
       case (EeaMachineReadable, paxCount) =>
-          Seq(SplitsPaxTypeAndQueueCount(EeaMachineReadable, EeaDesk, paxCount))
+        Seq(SplitsPaxTypeAndQueueCount(EeaMachineReadable, EeaDesk, paxCount))
+      case (Transit, c) => Seq(SplitsPaxTypeAndQueueCount(Transit, Transfer, c))
       case (otherPaxType, c) => Seq(SplitsPaxTypeAndQueueCount(otherPaxType, NonEeaDesk, c))
     }
   }
+
   def calculateQueuesFromPaxTypes(paxTypeAndCount: (PaxType, Int), egatePercentag: Double): Seq[SplitsPaxTypeAndQueueCount] = {
     paxTypeAndCount match {
       case (EeaNonMachineReadable, paxCount) =>
@@ -72,7 +74,8 @@ object PassengerTypeCalculator {
   def paxTypes(passengerInfos: Seq[PassengerInfoJson]) = {
     passengerInfos.map {
       (pi) =>
-        paxType(pi.EEAFlag, pi.DocumentIssuingCountryCode, pi.DocumentType)
+        if (pi.InTransitFlag == "Y") Transit else
+          paxType(pi.EEAFlag, pi.DocumentIssuingCountryCode, pi.DocumentType)
     }
   }
 

--- a/server/src/main/scala/passengersplits/parsing/VoyageManifestParser.scala
+++ b/server/src/main/scala/passengersplits/parsing/VoyageManifestParser.scala
@@ -9,13 +9,25 @@ import scala.util.Try
 
 object VoyageManifestParser {
 
+
+  def parseVoyagePassengerInfo(content: String): Try[VoyageManifest] = {
+    import FlightPassengerInfoProtocol._
+    import spray.json._
+    Try(content.parseJson.convertTo[VoyageManifest])
+  }
+
   case class PassengerInfo(DocumentType: Option[String],
                            DocumentIssuingCountryCode: String, Age: Option[Int] = None)
 
   case class PassengerInfoJson(DocumentType: Option[String],
                                DocumentIssuingCountryCode: String,
                                EEAFlag: String,
-                               Age: Option[String] = None) {
+                               Age: Option[String] = None,
+                               DisembarkationPortCode: Option[String],
+                               InTransitFlag: String = "N",
+                               DisembarkationPortCountryCode: Option[String] = None,
+                               NationalityCountryCode: Option[String] = None
+                              ) {
     def toPassengerInfo = PassengerInfo(DocumentType, DocumentIssuingCountryCode, Age match {
       case Some(age) => Try(age.toInt).toOption
       case None => None
@@ -49,8 +61,16 @@ object VoyageManifestParser {
   }
 
   object FlightPassengerInfoProtocol extends DefaultJsonProtocol {
-    implicit val passengerInfoConverter = jsonFormat(PassengerInfoJson, "DocumentType",
-      "DocumentIssuingCountryCode", "NationalityCountryEEAFlag", "Age")
+    implicit val passengerInfoConverter = jsonFormat(PassengerInfoJson,
+      "DocumentType",
+      "DocumentIssuingCountryCode",
+      "NationalityCountryEEAFlag",
+      "Age",
+      "DisembarkationPortCode",
+      "InTransitFlag",
+      "DisembarkationPortCountryCode",
+      "NationalityCountryCode"
+    )
     implicit val passengerInfoResponseConverter: RootJsonFormat[VoyageManifest] = jsonFormat8(VoyageManifest)
   }
 

--- a/server/src/main/scala/passengersplits/polling/ManifestFilePolling.scala
+++ b/server/src/main/scala/passengersplits/polling/ManifestFilePolling.scala
@@ -313,7 +313,7 @@ object AtmosManifestFilePolling {
   = {
     manifests.map((flightManifest) => {
       logInfo(s"AdvPaxInfo: parsing manifest ${flightManifest.filename} from ${flightManifest.zipFilename}")
-      (flightManifest.zipFilename, flightManifest.filename, VoyagePassengerInfoParser.parseVoyagePassengerInfo(flightManifest.content))
+      (flightManifest.zipFilename, flightManifest.filename, VoyageManifestParser.parseVoyagePassengerInfo(flightManifest.content))
     })
   }
 }

--- a/server/src/main/scala/passengersplits/s3/S3Reader.scala
+++ b/server/src/main/scala/passengersplits/s3/S3Reader.scala
@@ -21,6 +21,7 @@ import passengersplits.core.{Core, CoreActors, CoreLogging, ZipUtils}
 import passengersplits.parsing.VoyageManifestParser
 import drt.shared.PassengerSplits.VoyagePaxSplits
 import drt.shared.SDateLike
+import passengersplits.parsing.VoyageManifestParser.VoyageManifest
 
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
@@ -161,7 +162,7 @@ class WorkerPool(flightPassengerInfoRouter: ActorRef) extends ActorSubscriber wi
       //      queue += sender
       // todo move this passengersplits.parsing to be part of the akka flow pipe? because then we can just apply a port level filter without akka stateful magic.
       // ln(s"Found a file content $filename")
-      val parsed = VoyagePassengerInfoParser.parseVoyagePassengerInfo(content)
+      val parsed = VoyageManifestParser.parseVoyagePassengerInfo(content)
       log.info(s"flubflub ${parsed}")
       parsed match {
         case Success(voyagePassengerInfo) =>
@@ -209,7 +210,7 @@ class SplitCalculatorWorkerPool extends ActorSubscriber with ActorLogging {
 }
 
 
-object VoyagePassengerInfoParser {
+object VoyageManifestParser {
 
   import VoyageManifestParser._
   import FlightPassengerInfoProtocol._

--- a/server/src/main/scala/passengersplits/s3/S3Reader.scala
+++ b/server/src/main/scala/passengersplits/s3/S3Reader.scala
@@ -18,9 +18,9 @@ import com.mfglabs.commons.aws.s3.{AmazonS3AsyncClient, S3StreamBuilder}
 import passengersplits._
 import passengersplits.core.ZipUtils.UnzippedFileContent
 import passengersplits.core.{Core, CoreActors, CoreLogging, ZipUtils}
-import passengersplits.parsing.VoyageManifestParser
 import drt.shared.PassengerSplits.VoyagePaxSplits
 import drt.shared.SDateLike
+import passengersplits.parsing.VoyageManifestParser
 import passengersplits.parsing.VoyageManifestParser.VoyageManifest
 
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -148,7 +148,6 @@ object WorkerPool {
 class WorkerPool(flightPassengerInfoRouter: ActorRef) extends ActorSubscriber with ActorLogging {
 
   import ActorSubscriberMessage._
-  import VoyageManifestParser._
 
   val MaxQueueSize = 10
   var queue = Map.empty[Int, ActorRef]
@@ -207,19 +206,6 @@ class SplitCalculatorWorkerPool extends ActorSubscriber with ActorLogging {
       log.error(s"WorkerPool got unknown ${unknown}")
   }
 
-}
-
-
-object VoyageManifestParser {
-
-  import VoyageManifestParser._
-  import FlightPassengerInfoProtocol._
-  import VoyageManifestParser._
-  import spray.json._
-
-  def parseVoyagePassengerInfo(content: String): Try[VoyageManifest] = {
-    Try(content.parseJson.convertTo[VoyageManifest])
-  }
 }
 
 //trait S3Actors {

--- a/server/src/main/scala/services/PcpArrival.scala
+++ b/server/src/main/scala/services/PcpArrival.scala
@@ -21,6 +21,9 @@ object PcpArrival {
     }
   }
 
+  def walkTimeFromStringWithRounding(walkTimeCsvLine: String): Option[WalkTime] =
+    walkTimeFromString(walkTimeCsvLine).map(wt => wt.copy(walkTimeMillis = timeToNearestMinute(wt.walkTimeMillis)))
+
   def walkTimeFromString(walkTimeCsvLine: String): Option[WalkTime] = walkTimeCsvLine.split(",") match {
     case Array(from, walkTime, terminal) =>
       Try(walkTime.toInt) match {
@@ -37,14 +40,27 @@ object PcpArrival {
 
   def walkTimeMillisProviderFromCsv(walkTimesCsvFileUrl: String): GateOrStandWalkTime = {
     val walkTimes = walkTimesLinesFromFileUrl(walkTimesCsvFileUrl)
-      .map(walkTimeFromString)
+      .map(walkTimeFromStringWithRounding)
       .collect {
         case Some(wt) =>
           log.info(s"Loaded WalkTime $wt")
           wt
       }.map(x => ((x.from, x.to), x.walkTimeMillis)).toMap
-    walkTimeMillis(walkTimes) _
+
+    walkTimeMillis(roundTimesToNearestMinute(walkTimes)) _
   }
+
+  private def roundTimesToNearestMinute(walkTimes: Map[(String, String), Millis]) = {
+    /*
+    times must be rounded to the nearest minute because
+    a) any more precision than that is nonsense
+    b) the client operates in minutes and stitches things together on minute boundary.
+     */
+    walkTimes.mapValues(timeToNearestMinute)
+  }
+
+  import Math.round
+  def timeToNearestMinute(t: Millis) = round(t / 60000d) * 60000
 
   type GateOrStand = String
   type Millis = Long
@@ -63,16 +79,18 @@ object PcpArrival {
       0L
     })
     val walkTimeMillis = walkTimeForFlight(flight)
-
-    MilliDate(bestChoxTimeMillis + firstPaxOffMillis + walkTimeMillis)
+    val date = MilliDate(bestChoxTimeMillis + firstPaxOffMillis + walkTimeMillis)
+    log.debug(s"bestChoxTime for ${Arrival.summaryString(flight)} is ${bestChoxTimeMillis} or ${SDate(bestChoxTimeMillis).toLocalDateTimeString()}, firstPcp ${SDate(date.millisSinceEpoch).toLocalDateTimeString()}")
+    date
   }
 
   def gateOrStandWalkTimeCalculator(gateWalkTimesProvider: GateOrStandWalkTime,
                                     standWalkTimesProvider: GateOrStandWalkTime,
                                     defaultWalkTimeMillis: Millis)(flight: Arrival): Millis = {
-    standWalkTimesProvider(flight.Stand, flight.Terminal).getOrElse(
+    val walkTime = standWalkTimesProvider(flight.Stand, flight.Terminal).getOrElse(
       gateWalkTimesProvider(flight.Gate, flight.Terminal).getOrElse(defaultWalkTimeMillis))
-
+    log.debug(s"walkTimeForFlight ${Arrival.summaryString(flight)} is $walkTime millis ${walkTime / 60000} mins default is $defaultWalkTimeMillis")
+    walkTime
   }
 
   def bestChoxTime(timeToChoxMillis: Long, flight: Arrival): Option[Millis] = {

--- a/server/src/main/scala/services/SDate.scala
+++ b/server/src/main/scala/services/SDate.scala
@@ -28,6 +28,8 @@ object SDate {
 
     def addHours(hoursToAdd: Int): SDateLike = dateTime.plusHours(hoursToAdd)
 
+    def addMinutes(mins: Int): SDateLike = dateTime.plusMinutes(mins)
+
     def millisSinceEpoch: Long = dateTime.getMillis
 
 

--- a/server/src/main/scala/services/workloadcalculator/WorkloadCalculator.scala
+++ b/server/src/main/scala/services/workloadcalculator/WorkloadCalculator.scala
@@ -137,6 +137,7 @@ object PaxLoadCalculator {
     val pcpStartTimeMillis = MilliDate(flight.PcpTime).millisSinceEpoch
     //TODO fix this get
     val splits = splitsRatioProvider(flight).get.splits
+    log.info(s"voyagePaxSplits $splits")
     val splitsOverTime: IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = minutesForHours(pcpStartTimeMillis, 1)
       .zip(paxDeparturesPerMinutes(bestPax(flight), paxOffFlowRate))
       .flatMap {

--- a/server/src/test/scala/controllers/FlightsPersistenceSpec.scala
+++ b/server/src/test/scala/controllers/FlightsPersistenceSpec.scala
@@ -70,9 +70,9 @@ class FlightsPersistenceSpec extends AkkaTestkitSpecs2SupportForPersistence("tar
       val arrivals = List(apiFlight(flightId = 1, iata = "SA0123", airportId = "STN", actPax = 100, schDt = "2017-10-02T20:00:00Z"))
       setFlightsAndStopActors(arrivals)
 
-      val result = getFlightsAsSet
-      val expected = Set(apiFlight(flightId = 1, iata = "SA0123", airportId = "STN", actPax = 100, schDt = "2017-10-02T20:00:00Z"))
+      val result = getFlightsAsSet()
 
+      val expected = Set(apiFlight(flightId = 1, iata = "SA0123", airportId = "STN", actPax = 100, schDt = "2017-10-02T20:00:00Z"))
       result === expected
     }
 
@@ -83,12 +83,12 @@ class FlightsPersistenceSpec extends AkkaTestkitSpecs2SupportForPersistence("tar
       )
       setFlightsStopAndSleep(flightsSet)
 
-      val result = getFlightsAsSet
+      val result = getFlightsAsSet()
+
       val expected = Set(
         apiFlight(flightId = 1, iata = "SA0123", airportId = "JFK", actPax = 100, schDt = "2017-10-02T20:00:00Z"),
         apiFlight(flightId = 2, iata = "BA0001", airportId = "JFK", actPax = 150, schDt = "2017-10-02T21:55:00Z")
       )
-
       result === expected
     }
   }
@@ -106,7 +106,7 @@ class FlightsPersistenceSpec extends AkkaTestkitSpecs2SupportForPersistence("tar
     Thread.sleep(100L)
   }
 
-  def getFlightsAsSet = {
+  def getFlightsAsSet() = {
     val (flightsActorRef2, crunchActorRef2) = flightsAndCrunchActors(system)
     val futureResult = flightsActorRef2 ? GetFlights
 

--- a/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
+++ b/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
@@ -159,7 +159,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
         def zipFilenameToEventualFileContent(zipFileName: String) = {
           Future {
-            Thread.sleep(1000) /// take longer than we need, but not too long
             UnzippedFileContent("drt_160302_060000_FR3631_DC_4089.json",
               """
 {"EventCode": "DC", "DeparturePortCode": "SVG", "VoyageNumberTrailingLetter": "", "ArrivalPortCode": "ABZ", "DeparturePortCountryCode": "NOR", "VoyageNumber": "3631", "VoyageKey": "a1c9cbec34df3f33ca5e1e934f920364", "ScheduledDateOfDeparture": "2016-03-03", "ScheduledDateOfArrival": "2016-03-03", "CarrierType": "AIR", "CarrierCode": "FR", "ScheduledTimeOfDeparture": "08:05:00", "PassengerList": [{"DocumentIssuingCountryCode": "BWA", "PersonType": "P", "DocumentLevel": "Primary", "Age": "61", "DisembarkationPortCode": "ABZ", "InTransitFlag": "N", "DisembarkationPortCountryCode": "GBR", "NationalityCountryEEAFlag": "", "DocumentType": "P", "PoavKey": "1768895616a4fd245b3a2c31f8fbd407", "NationalityCountryCode": "BWA"}], "ScheduledTimeOfArrival": "09:10:00", "FileId": "drt_160302_060000_FR3631_DC_4089"}
@@ -185,8 +184,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
         batchAtMost,
         alwaysTrue
       )
-
-      val expectedZipFile = zipFilename
 
       pollingFuture.onFailure {
         case f: Throwable => {
@@ -218,7 +215,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
         def zipFilenameToEventualFileContent(zipFileName: String) = {
           Future {
-            Thread.sleep(1000) /// take longer than we need, but not too long
             UnzippedFileContent("drt_160302_060000_BA0001_CI_4089.json",
               """
 {"EventCode": "CI", "DeparturePortCode": "SVG", "VoyageNumberTrailingLetter": "", "ArrivalPortCode": "LHR", "DeparturePortCountryCode": "NOR", "VoyageNumber": "3631", "VoyageKey": "a1c9cbec34df3f33ca5e1e934f920364", "ScheduledDateOfDeparture": "2016-03-03", "ScheduledDateOfArrival": "2016-03-03", "CarrierType": "AIR", "CarrierCode": "FR", "ScheduledTimeOfDeparture": "08:05:00", "PassengerList": [{"DocumentIssuingCountryCode": "BWA", "PersonType": "P", "DocumentLevel": "Primary", "Age": "61", "DisembarkationPortCode": "ABZ", "InTransitFlag": "N", "DisembarkationPortCountryCode": "GBR", "NationalityCountryEEAFlag": "", "DocumentType": "P", "PoavKey": "1768895616a4fd245b3a2c31f8fbd407", "NationalityCountryCode": "BWA"}], "ScheduledTimeOfArrival": "09:10:00", "FileId": "drt_160302_060000_FR3631_DC_4089"}
@@ -251,8 +247,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
         voyageManifestFilter
       )
 
-      val expectedZipFile = zipFilename
-
       pollingFuture.onFailure {
         case f: Throwable => {
           system.log.error(f, "failure on outer batches")
@@ -263,7 +257,7 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
         case VoyageManifest("CI", "LHR", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
-        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("ABZ"), "N", Some("GBR"), Some("BWA")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")
@@ -283,7 +277,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
         def zipFilenameToEventualFileContent(zipFileName: String) = {
           Future {
-            Thread.sleep(1000) /// take longer than we need, but not too long
             UnzippedFileContent("drt_160302_060000_BA0001_CI_4089.json",
               """
 {"EventCode": "CI", "DeparturePortCode": "SVG", "VoyageNumberTrailingLetter": "", "ArrivalPortCode": "LHR", "DeparturePortCountryCode": "NOR", "VoyageNumber": "3631", "VoyageKey": "a1c9cbec34df3f33ca5e1e934f920364", "ScheduledDateOfDeparture": "2016-03-03", "ScheduledDateOfArrival": "2016-03-03", "CarrierType": "AIR", "CarrierCode": "FR", "ScheduledTimeOfDeparture": "08:05:00", "PassengerList": [{"DocumentIssuingCountryCode": "BWA", "PersonType": "P", "DocumentLevel": "Primary", "Age": "61", "DisembarkationPortCode": "ABZ", "InTransitFlag": "N", "DisembarkationPortCountryCode": "GBR", "NationalityCountryEEAFlag": "", "DocumentType": "P", "PoavKey": "1768895616a4fd245b3a2c31f8fbd407", "NationalityCountryCode": "BWA"}], "ScheduledTimeOfArrival": "09:10:00", "FileId": "drt_160302_060000_FR3631_DC_4089"}
@@ -328,7 +321,7 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
         case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
-        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("ABZ"), "N", Some("GBR"), Some("BWA")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")
@@ -391,7 +384,7 @@ class WhenUnzippingOnlyProcessAppropriateMessagesAtAHigherScopeSpec extends Test
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
         case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
-        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("ABZ"), "N", Some("GBR"), Some("BWA")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")

--- a/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
+++ b/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
@@ -197,7 +197,8 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
-        case VoyageManifest("CI", "ABZ", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(PassengerInfoJson(Some("P"), "BWA", "", Some("61")))) :: Nil =>
+        case VoyageManifest("CI", "ABZ", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("ABZ"), "N", Some("GBR"), Some("BWA")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")
@@ -261,7 +262,8 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
-        case VoyageManifest("CI", "LHR", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(PassengerInfoJson(Some("P"), "BWA", "", Some("61")))) :: Nil =>
+        case VoyageManifest("CI", "LHR", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")
@@ -325,7 +327,8 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
-        case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(PassengerInfoJson(Some("P"), "BWA", "", Some("61")))) :: Nil =>
+        case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")
@@ -387,7 +390,8 @@ class WhenUnzippingOnlyProcessAppropriateMessagesAtAHigherScopeSpec extends Test
 
       Await.ready(pollingFuture, 2 seconds)
       testQueue.toList match {
-        case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(PassengerInfoJson(Some("P"), "BWA", "", Some("61")))) :: Nil =>
+        case VoyageManifest("CI", "BHX", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
+        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("Ab"), "", Some(""), Some("")))) :: Nil =>
           true
         case f =>
           system.log.error(s"Got $f")

--- a/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
+++ b/server/src/test/scala/passengersplits/AtmosFileUnzipperSpec.scala
@@ -148,62 +148,6 @@ class WhenUnzippingOnlyProcessAppropriateMessagesSpec extends TestKit(ActorSyste
 
   val batchAtMost: FiniteDuration = 3 seconds
 
-  "Given one zip file containing 2 json files, one being CI and one being DC " >> {
-    "When we process it " +
-      "Then the actor only receives the CI message" >> {
-      val oneTick = Source(List(new DateTime(2017, 1, 1, 12, 33, 20)))
-      val zipFilename = "drt_dq_170411_104441_4850.zip"
-      val fileProvider = new FileProvider {
-
-        def createFilenameSource(): Source[String, NotUsed] = Source(List(zipFilename))
-
-        def zipFilenameToEventualFileContent(zipFileName: String) = {
-          Future {
-            UnzippedFileContent("drt_160302_060000_FR3631_DC_4089.json",
-              """
-{"EventCode": "DC", "DeparturePortCode": "SVG", "VoyageNumberTrailingLetter": "", "ArrivalPortCode": "ABZ", "DeparturePortCountryCode": "NOR", "VoyageNumber": "3631", "VoyageKey": "a1c9cbec34df3f33ca5e1e934f920364", "ScheduledDateOfDeparture": "2016-03-03", "ScheduledDateOfArrival": "2016-03-03", "CarrierType": "AIR", "CarrierCode": "FR", "ScheduledTimeOfDeparture": "08:05:00", "PassengerList": [{"DocumentIssuingCountryCode": "BWA", "PersonType": "P", "DocumentLevel": "Primary", "Age": "61", "DisembarkationPortCode": "ABZ", "InTransitFlag": "N", "DisembarkationPortCountryCode": "GBR", "NationalityCountryEEAFlag": "", "DocumentType": "P", "PoavKey": "1768895616a4fd245b3a2c31f8fbd407", "NationalityCountryCode": "BWA"}], "ScheduledTimeOfArrival": "09:10:00", "FileId": "drt_160302_060000_FR3631_DC_4089"}
-          """.stripMargin, Option(zipFilename)) ::
-              UnzippedFileContent("drt_160302_060000_FR3631_CI_4089.json",
-                """
-{"EventCode": "CI", "DeparturePortCode": "SVG", "VoyageNumberTrailingLetter": "", "ArrivalPortCode": "ABZ", "DeparturePortCountryCode": "NOR", "VoyageNumber": "3631", "VoyageKey": "a1c9cbec34df3f33ca5e1e934f920364", "ScheduledDateOfDeparture": "2016-03-03", "ScheduledDateOfArrival": "2016-03-03", "CarrierType": "AIR", "CarrierCode": "FR", "ScheduledTimeOfDeparture": "08:05:00", "PassengerList": [{"DocumentIssuingCountryCode": "BWA", "PersonType": "P", "DocumentLevel": "Primary", "Age": "61", "DisembarkationPortCode": "ABZ", "InTransitFlag": "N", "DisembarkationPortCountryCode": "GBR", "NationalityCountryEEAFlag": "", "DocumentType": "P", "PoavKey": "1768895616a4fd245b3a2c31f8fbd407", "NationalityCountryCode": "BWA"}], "ScheduledTimeOfArrival": "09:10:00", "FileId": "drt_160302_060000_FR3631_DC_4089"}
-          """.stripMargin, Option(zipFilename)) :: Nil
-          }
-        }
-
-      }
-
-      val testQueue = mutable.Queue[VoyageManifest]()
-
-      val flightPassengerSplitReporter = system.actorOf(Props(classOf[SimpleTestRouter], testQueue), name = "flight-pax-reporter")
-
-      val batchFileState = new SignallingBatchFileState("", "drt_dq_170411_104441_4850.zip" :: Nil)
-      val pollingFuture = AtmosManifestFilePolling.beginPollingImpl(flightPassengerSplitReporter,
-        oneTick,
-        fileProvider,
-        batchFileState,
-        batchAtMost,
-        alwaysTrue
-      )
-
-      pollingFuture.onFailure {
-        case f: Throwable => {
-          system.log.error(f, "failure on outer batches")
-          failure
-        }
-      }
-
-      Await.ready(pollingFuture, 2 seconds)
-      testQueue.toList match {
-        case VoyageManifest("CI", "ABZ", "SVG", "3631", "FR", "2016-03-03", "09:10:00", List(
-        PassengerInfoJson(Some("P"), "BWA", "", Some("61"), Some("ABZ"), "N", Some("GBR"), Some("BWA")))) :: Nil =>
-          true
-        case f =>
-          system.log.error(s"Got $f")
-          false
-      }
-    }
-  }
-
   "Given one zip file containing 2 CI json files, one LHR and one BHX and our active port is LHR" >> {
     "When we process it " +
       "Then the actor only receives the LHR message" >> {

--- a/server/src/test/scala/passengersplits/CanFindASplitForAnApiFlightSpec.scala
+++ b/server/src/test/scala/passengersplits/CanFindASplitForAnApiFlightSpec.scala
@@ -34,9 +34,13 @@ class CanFindASplitForAnApiFlightSpec extends
   }
 
   "Should be able to find a flight" >> {
+    def paxInfo(documentType: Some[String] = Some("P"),
+                documentIssuingCountryCode: String = "GBR", eeaFlag: String = "EEA", age: Option[String] = None): PassengerInfoJson =
+      PassengerInfoJson(documentType, documentIssuingCountryCode, eeaFlag, age, None,
+        DisembarkationPortCountryCode =  None)
     "Given a single flight, with just one GBR passenger" in {
       flightPassengerReporter ! VoyageManifest(EventCodes.DoorsClosed, "LGW", "BRG", "12345", "EZ", "2017-04-02", "15:33:00",
-        PassengerInfoJson(Some("P"), "GBR", "EEA", None) :: Nil)
+        paxInfo() :: Nil)
 
       "When we ask for a report of voyage pax splits then we should see pax splits of the 1 passenger in eeaDesk queue" in {
         val flightScheduledDateTime = SDate(2017, 4, 2, 15, 33)
@@ -50,8 +54,8 @@ class CanFindASplitForAnApiFlightSpec extends
     "Given a single flight STN EZ789 flight, with just one GBR and one nationals passenger" in {
       "When we ask for a report of voyage pax splits" in {
         flightPassengerReporter ! VoyageManifest(EventCodes.DoorsClosed, "STN", "BRG", "789", "EZ", "2015-02-01", "13:55:00",
-          PassengerInfoJson(Some("P"), "GBR", "EEA", None) ::
-            PassengerInfoJson(Some("P"), "NZL", "", None) ::
+          paxInfo() ::
+            PassengerInfoJson(Some("P"), "NZL", "", None, DisembarkationPortCode = Some("STN")) ::
             Nil)
 
         val scheduleArrivalTime = SDate(2015, 2, 1, 13, 55)
@@ -68,8 +72,8 @@ class CanFindASplitForAnApiFlightSpec extends
     "Given a single flight STN EZ789 flight where the scheduled date is in British Summer Time (BST) with just one GBR and one nationals passenger" in {
       "When we ask for a report of voyage pax splits" in {
         flightPassengerReporter ! VoyageManifest(EventCodes.DoorsClosed, "STN", "BRG", "789", "EZ", "2017-03-27", "12:10:00",
-          PassengerInfoJson(Some("P"), "GBR", "EEA", None) ::
-            PassengerInfoJson(Some("P"), "NZL", "", None) ::
+          paxInfo() ::
+            PassengerInfoJson(Some("P"), "NZL", "", None, DisembarkationPortCode = Some("STN")) ::
             Nil)
 
         val scheduleArrivalTime = SDate(2017, 3,27, 12, 10)
@@ -86,8 +90,8 @@ class CanFindASplitForAnApiFlightSpec extends
     "Given a single flight STN BA978 flight, with 100 passengers, and a default egate usage of 60% - " in  {
       "When we ask for a report of voyage pax splits" in {
         flightPassengerReporter ! VoyageManifest(EventCodes.DoorsClosed, "STN", "BCN", "978", "BA", "2015-07-12", "10:22:00",
-          List.tabulate(80)(passengerNumber => PassengerInfoJson(Some("P"), "GBR", "EEA", Some((passengerNumber % 60 + 16).toString))) :::
-            List.tabulate(20)(_ => PassengerInfoJson(Some("P"), "NZL", "", None)))
+          List.tabulate(80)(passengerNumber => PassengerInfoJson(Some("P"), "GBR", "EEA", Some((passengerNumber % 60 + 16).toString), DisembarkationPortCode = Some("STN"))) :::
+            List.tabulate(20)(_ => PassengerInfoJson(Some("P"), "NZL", "", None, DisembarkationPortCode = Some("STN"))))
 
         val scheduleArrivalSDate: SDateLike = SDate(2015, 7, 12, 10, 22)
         flightPassengerReporter ! ReportVoyagePaxSplit("STN", "BA", "978", scheduleArrivalSDate)

--- a/server/src/test/scala/passengersplits/FlightPassengerInfoRouterActorSpec.scala
+++ b/server/src/test/scala/passengersplits/FlightPassengerInfoRouterActorSpec.scala
@@ -27,7 +27,7 @@ class WhenReportingVoyageManifestsSpec extends TestKit(ActorSystem("AkkaStreamTe
       val flightPassengerSplitReporter = system.actorOf(Props[PassengerSplitsInfoByPortRouter], name = "flight-pax-reporter")
 
       val civm = VoyageManifest(EventCodes.CheckIn, "LHR", "JFK", "0123", "BA", "2017-01-01", "00:00:00", List(
-        PassengerInfoJson(None, "GB", "", None)
+        PassengerInfoJson(None, "GB", "", None, None, "N", None, None)
       ))
 
       flightPassengerSplitReporter ! civm
@@ -51,7 +51,7 @@ class WhenReportingVoyageManifestsSpec extends TestKit(ActorSystem("AkkaStreamTe
       val flightPassengerSplitReporter = system.actorOf(Props[PassengerSplitsInfoByPortRouter], name = "flight-pax-reporter")
 
       val dcvm = VoyageManifest(EventCodes.DoorsClosed, "LHR", "JFK", "0123", "BA", "2017-01-01", "00:00:00", List(
-        PassengerInfoJson(None, "GB", "", None)
+        PassengerInfoJson(None, "GB", "", None, None, "N", None, None)
       ))
 
       flightPassengerSplitReporter ! dcvm
@@ -104,8 +104,8 @@ class WhenReportingVoyageManifestsSpec extends TestKit(ActorSystem("AkkaStreamTe
 
     val flightPassengerSplitReporter = system.actorOf(Props[PassengerSplitsInfoByPortRouter], name = "flight-pax-reporter")
 
-    val ciPax = List.fill(ciPaxCount)(PassengerInfoJson(None, "GB", "", None))
-    val diPax = List.fill(diPaxCount)(PassengerInfoJson(None, "GB", "", None))
+    val ciPax = List.fill(ciPaxCount)(PassengerInfoJson(None, "GB", "", None, None, "N", None, None))
+    val diPax = List.fill(diPaxCount)(PassengerInfoJson(None, "GB", "", None, None, "N", None, None))
     val civm = VoyageManifest(EventCodes.CheckIn, portCode, "JFK", flightNumber, carrierCode, schDate, schTime, ciPax)
     val dcvm = VoyageManifest(EventCodes.DoorsClosed, portCode, "JFK", flightNumber, carrierCode, schDate, schTime, diPax)
 

--- a/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
+++ b/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
@@ -23,18 +23,27 @@ class PaxTransferSpecs extends Specification {
     """
 
   def transferPaxAreRemovedFromSplits = {
-    s2"""
-    Given A Flight, with 2 pax on it, and 1 of them is a transfer passenger,
-      When we calculate the splits,
-      Then we do NOT see them in the split counts
-      $e1
-    """
 
     def e1 = {
-      val vpi = VoyageManifest(EventCodes.CI, "LHR", "___", "123", "BA", "2017/05/12", "10:15",
-        PassengerInfoJson(Some("P"), )
+      val vpi = VoyageManifest(EventCodes.CheckIn, "LHR", "___", "123", "BA", "2017/05/12", "10:15",
+        PassengerInfoJson(Some("P"), "GBR", "EEA", Some("23"),
+          DisembarkationPortCode = Some("LHR"), InTransitFlag = "N", DisembarkationPortCountryCode = Some("GBR"),
+          NationalityCountryCode = None) ::
+          PassengerInfoJson(Some("P"), DocumentIssuingCountryCode = "GBR", EEAFlag = "EEA", Age = Some("45"),
+            DisembarkationPortCode = Some("COL"), InTransitFlag = "Y", DisembarkationPortCountryCode = Some("MNP"),
+            NationalityCountryCode = None) :: Nil
       )
+
+
+      pending("what?")
     }
+    s2"""
+    Given A Flight, with 2 pax on it, and 1 of them is a transfer passenger,
+    When we calculate the splits,
+    Then we do NOT see them in the split counts
+    $e1
+    """
   }
+
   def transferPaxCanBeRetrievedIndependently = pending("tbd")
 }

--- a/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
+++ b/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
@@ -29,9 +29,9 @@ class PaxTransferSpecs extends Specification with specification.dsl.GWT with Sta
 
   def transferPaxGoToATransferQueue =
     s2"""
-    Given A Flight $createFlight
+    - Given A Flight $createFlight
      And the flight has passengers
-     And a Passenger is from {UK} {InTransit} disembarking {BCN} $addPassenger
+     And a Passenger is from {DEU} {InTransit} disembarking {BCN} $addPassenger
      And a Passenger is from {DEU} {NotInTransit} disembarking {LHR} $addPassenger
     When we calculate the splits $calcSplits
     Then we do NOT see them in the split counts

--- a/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
+++ b/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
@@ -1,9 +1,14 @@
 package passengersplits
 
+import drt.shared.PassengerQueueTypes.PaxTypeAndQueueCounts
+import drt.shared.PassengerSplits.SplitsPaxTypeAndQueueCount
+import drt.shared.Queues
 import org.specs2._
+import org.specs2.specification.script.StandardDelimitedStepParsers
+import passengersplits.core.PassengerQueueCalculator
 import passengersplits.parsing.VoyageManifestParser.{EventCodes, PassengerInfo, PassengerInfoJson, VoyageManifest}
 
-class PaxTransferSpecs extends Specification {
+class PaxTransferSpecs extends Specification with specification.dsl.GWT with StandardDelimitedStepParsers {
   def is =
     s2"""
     This is a specification of passenger splits with transfer passengers from the DQ Advance Passenger Info (API) feed
@@ -16,33 +21,60 @@ class PaxTransferSpecs extends Specification {
         |
         |opt - It would be useful to see the number of international and domestic transfers - hover over could be used?
         |
-        |$transferPaxAreRemovedFromSplits
+        |TransferQueue
+        | - $transferPaxGoToATransferQueue
         |
-        |$transferPaxCanBeRetrievedIndependently
         |
     """
 
-  def transferPaxAreRemovedFromSplits = {
-
-    def e1 = {
-      val vpi = VoyageManifest(EventCodes.CheckIn, "LHR", "___", "123", "BA", "2017/05/12", "10:15",
-        PassengerInfoJson(Some("P"), "GBR", "EEA", Some("23"),
-          DisembarkationPortCode = Some("LHR"), InTransitFlag = "N", DisembarkationPortCountryCode = Some("GBR"),
-          NationalityCountryCode = None) ::
-          PassengerInfoJson(Some("P"), DocumentIssuingCountryCode = "GBR", EEAFlag = "EEA", Age = Some("45"),
-            DisembarkationPortCode = Some("COL"), InTransitFlag = "Y", DisembarkationPortCountryCode = Some("MNP"),
-            NationalityCountryCode = None) :: Nil
-      )
-
-
-      pending("what?")
-    }
+  def transferPaxGoToATransferQueue =
     s2"""
-    Given A Flight, with 2 pax on it, and 1 of them is a transfer passenger,
-    When we calculate the splits,
+    Given A Flight $createFlight
+     And the flight has passengers
+     And a Passenger is from {UK} {InTransit} disembarking {BCN} $addPassenger
+     And a Passenger is from {DEU} {NotInTransit} disembarking {LHR} $addPassenger
+    When we calculate the splits $calcSplits
     Then we do NOT see them in the split counts
-    $e1
+    SplitCounts are eeaDesk {1} transfers {1} $assertSplits
     """
+
+  var currentFlight: Option[VoyageManifest] = None
+  var calculatedSplits: List[SplitsPaxTypeAndQueueCount] = Nil
+
+  def splitsByQueue = calculatedSplits.groupBy(_.queueType).mapValues(v => v.map(_.paxCount).sum)
+
+  def createFlight = step {
+    println(s"create a flight")
+    currentFlight = Some(VoyageManifest(EventCodes.CheckIn, "LHR", "MON", "123", "RYR", "2017-05-02", "10:33:00", Nil))
+  }
+
+  def addPassenger = step(threeStrings) {
+    case (countryCode: String, transferState: String, disembarkation: String) => {
+      println(s"passenger is $countryCode $transferState")
+
+      val inTransit = transferState match {
+        case "InTransit" => "Y"
+        case "NotInTransit" => "N"
+      }
+
+      val newPassenger = PassengerInfoJson(Some("P"), countryCode, EEAFlag = "EEA", None, Some(disembarkation), inTransit)
+      currentFlight = currentFlight.map(f => f.copy(PassengerList = newPassenger :: f.PassengerList))
+      println(s"flight is now $currentFlight")
+    }
+  }
+
+  def calcSplits = step {
+    for (flight <- currentFlight) {
+      calculatedSplits = PassengerQueueCalculator.convertPassengerInfoToPaxQueueCounts(flight.PassengerList, 0).toList
+    }
+  }
+
+  def assertSplits = example(twoInts) {
+    case (eea: Int, transfer: Int) => {
+      println(s"expected splits are $eea $transfer")
+      println(s"actualSplits are $splitsByQueue")
+      (Map(Queues.EeaDesk -> eea, Queues.Transfer -> transfer) must_== splitsByQueue)
+    }
   }
 
   def transferPaxCanBeRetrievedIndependently = pending("tbd")

--- a/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
+++ b/server/src/test/scala/passengersplits/PaxTransferSpecs.scala
@@ -1,0 +1,40 @@
+package passengersplits
+
+import org.specs2._
+import passengersplits.parsing.VoyageManifestParser.{EventCodes, PassengerInfo, PassengerInfoJson, VoyageManifest}
+
+class PaxTransferSpecs extends Specification {
+  def is =
+    s2"""
+    This is a specification of passenger splits with transfer passengers from the DQ Advance Passenger Info (API) feed
+
+        |As an LHR SO user of DRT I would like to see the transfer passengers that are arriving for a flight.
+        |The transfer passengers should be removed from the API pax numbers arriving at the PCP and displayed separately in a Transfer column.
+        |This will ensure that I know the number of passengers that should be seen at PCP from a flight,
+        |it will also highlight the number of additional passengers that could be seen by the
+        |PCP if the arrival of the flight is delayed and the passengers miss their connecting flight.
+        |
+        |opt - It would be useful to see the number of international and domestic transfers - hover over could be used?
+        |
+        |$transferPaxAreRemovedFromSplits
+        |
+        |$transferPaxCanBeRetrievedIndependently
+        |
+    """
+
+  def transferPaxAreRemovedFromSplits = {
+    s2"""
+    Given A Flight, with 2 pax on it, and 1 of them is a transfer passenger,
+      When we calculate the splits,
+      Then we do NOT see them in the split counts
+      $e1
+    """
+
+    def e1 = {
+      val vpi = VoyageManifest(EventCodes.CI, "LHR", "___", "123", "BA", "2017/05/12", "10:15",
+        PassengerInfoJson(Some("P"), )
+      )
+    }
+  }
+  def transferPaxCanBeRetrievedIndependently = pending("tbd")
+}

--- a/server/src/test/scala/passengersplits/performance/FlightPassengerSplitsPerformanceSpec.scala
+++ b/server/src/test/scala/passengersplits/performance/FlightPassengerSplitsPerformanceSpec.scala
@@ -60,7 +60,14 @@ class FlightPassengerSplitsPerformanceSpec extends
     dicc <- Gen.oneOf(PassengerTypeCalculator.EEACountries.toSeq)
     eeaFlag = "EEA"
     age <- Gen.chooseNum(1, 99)
-  } yield PassengerInfoJson(Some(dt), dicc, eeaFlag, Some(age.toString))
+    disembarkation <- Gen.oneOf(Some("LHR"), Some("COL"))
+    inTransit <- Gen.oneOf("Y", "N")
+    disCc <- Gen.oneOf(Some("GBR"), Some("MNP"))
+    natCc <- Gen.oneOf(Some("GBR"), None)
+  } yield PassengerInfoJson(Some(dt), dicc, eeaFlag, Some(age.toString), DisembarkationPortCode = disembarkation,
+    InTransitFlag = inTransit,
+    DisembarkationPortCountryCode = disCc,
+    NationalityCountryCode = natCc)
 
   // todo figure out scala check Gen.parameters
   def flightGen(dateTime: DateTime): Gen[VoyageManifest] = for {

--- a/server/src/test/scala/s3/ZipSpec.scala
+++ b/server/src/test/scala/s3/ZipSpec.scala
@@ -46,7 +46,7 @@ class ZipSpec extends Specification with Matchers {
           false
       }
     }
-    "a PassengerInfo has origin country, and DocumentType" in {
+    "a PassengerInfo has DocumentType, origin country, age, destination country, and a transit flag" in {
       val results = ZipUtils.usingZip(new ZipInputStream(openResourceZip)) {
         zip =>
           val unzippedStream: Stream[UnzippedFileContent] = ZipUtils.unzipAllFilesInStream(zip)
@@ -57,7 +57,7 @@ class ZipSpec extends Specification with Matchers {
       results.toList match {
         case ("drt_160302_165000_SU2584_CI_0915.json",
         VoyageManifest(EventCodes.CheckIn, "LHR", departurePort,  "2584", "SU", "2016-03-02", "21:05:00",
-        PassengerInfoJson(Some("V"), "GTM", "", Some("67")) :: passengerInfoTail)) :: Nil => true
+        PassengerInfoJson(Some("V"), "GTM", "", Some("67"),  Some(dp), "", None, None) :: passengerInfoTail)) :: Nil => true
         case default =>
           assert(false, "Didn't match expectation, got: " + default)
           false

--- a/server/src/test/scala/s3/ZipSpec.scala
+++ b/server/src/test/scala/s3/ZipSpec.scala
@@ -57,7 +57,7 @@ class ZipSpec extends Specification with Matchers {
       results.toList match {
         case ("drt_160302_165000_SU2584_CI_0915.json",
         VoyageManifest(EventCodes.CheckIn, "LHR", departurePort,  "2584", "SU", "2016-03-02", "21:05:00",
-        PassengerInfoJson(Some("V"), "GTM", "", Some("67"),  Some(dp), "", None, None) :: passengerInfoTail)) :: Nil => true
+        PassengerInfoJson(Some("V"), "GTM", "", Some("67"),  Some(dp), "Y", Some("AUS"), Some("GTM")) :: passengerInfoTail)) :: Nil => true
         case default =>
           assert(false, "Didn't match expectation, got: " + default)
           false

--- a/server/src/test/scala/services/PcpArrivalSpec.scala
+++ b/server/src/test/scala/services/PcpArrivalSpec.scala
@@ -8,6 +8,43 @@ class PcpArrivalSpec extends SpecificationLike {
 
   import PcpArrival._
 
+
+  "DRT-4607 parseWalkTimeWithMinuteRounding" +
+    "We must round the walktimes to the nearest hour to keep the web client happy" +
+    "See DRT-4607 for the why. Perhaps we will revisit" >> {
+    "Given a valid walk time csv line string " +
+      " AND the walktime is 45 seconds" +
+      "then we should get back a WalkTime of 1 minutes" >> {
+      val validCsvLine = "101,45,T1"
+
+      val result = walkTimeFromStringWithRounding(validCsvLine)
+      val expected = Some(WalkTime("101", "T1", 60000L))
+
+      result === expected
+    }
+    "Given a valid walk time csv line string " +
+      " AND the walktime is 65 seconds" +
+      "then we should get back a WalkTime of 1 minutes" >> {
+      val validCsvLine = "101,65,T1"
+
+      val result = walkTimeFromStringWithRounding(validCsvLine)
+      val expected = Some(WalkTime("101", "T1", 60000L))
+
+      result === expected
+    }
+    "Given a valid walk time csv line string " +
+      " AND the walktime is 125 seconds" +
+      "then we should get back a WalkTime of 2 minutes (120000L)" >> {
+      val validCsvLine = "101,125,T1"
+
+      val result = walkTimeFromStringWithRounding(validCsvLine)
+      val expected = Some(WalkTime("101", "T1", 120000L))
+
+      result === expected
+    }
+  }
+
+
   "parseWalkTime" >> {
     "Given a valid walk time csv line string " +
       "then we should get back a WalkTime representing it" >> {
@@ -18,6 +55,7 @@ class PcpArrivalSpec extends SpecificationLike {
 
       result === expected
     }
+
 
     "Given a invalid walk time csv line string with a non-numeric walk time, " +
       "then we should get a None" >> {

--- a/shared/src/main/scala/spatutorial/shared/Api.scala
+++ b/shared/src/main/scala/spatutorial/shared/Api.scala
@@ -154,6 +154,8 @@ trait SDateLike {
 
   def addHours(hoursToAdd: Int): SDateLike
 
+  def addMinutes(minutesToAdd: Int): SDateLike
+
   def toLocalDateTimeString(): String = f"${getFullYear()}-${getMonth()}%02d-${getDate()}%02d ${getHours()}%02d:${getMinutes()}%02d"
 
   override def toString: String = f"${getFullYear()}-${getMonth()}%02d-${getDate()}%02dT${getHours()}%02d${getMinutes()}%02d"

--- a/shared/src/main/scala/spatutorial/shared/Api.scala
+++ b/shared/src/main/scala/spatutorial/shared/Api.scala
@@ -164,6 +164,7 @@ object CrunchResult {
   def empty = CrunchResult(0, 0, Vector[Int](), Nil)
 }
 
+
 case class CrunchResult(
                          firstTimeMillis: Long,
                          intervalMillis: Long,

--- a/shared/src/main/scala/spatutorial/shared/Api.scala
+++ b/shared/src/main/scala/spatutorial/shared/Api.scala
@@ -204,7 +204,7 @@ trait WorkloadsHelpers {
   def queueWorkloadsForPeriod(workloads: Map[String, Seq[WL]], periodMinutes: NumericRange[Long]): Map[String, List[Double]] = {
     workloads.mapValues((qwl: Seq[WL]) => {
       val queuesMinutesFoldedIntoWholeDay = foldQueuesMinutesIntoDay(periodMinutes, workloadToWorkLoadByTime(qwl))
-      queuesWorkloadByMinuteAsFullyPopulatedWorkloadSeq(queuesMinutesFoldedIntoWholeDay)
+      queuesWorkloadSortedByMinuteAsFullyPopulatedWorkloadSeq(queuesMinutesFoldedIntoWholeDay)
     })
   }
 
@@ -226,7 +226,7 @@ trait WorkloadsHelpers {
     workloads.mapValues(qwl => {
       val allPaxloadByMinuteForThisQueue: Map[Long, Double] = loadByMillis(qwl)
       val queuesMinutesFoldedIntoWholeDay = foldQueuesMinutesIntoDay(periodMinutes, allPaxloadByMinuteForThisQueue)
-      queuesWorkloadByMinuteAsFullyPopulatedWorkloadSeq(queuesMinutesFoldedIntoWholeDay)
+      queuesWorkloadSortedByMinuteAsFullyPopulatedWorkloadSeq(queuesMinutesFoldedIntoWholeDay)
     })
   }
 
@@ -237,7 +237,7 @@ trait WorkloadsHelpers {
   def workloadsByPeriod(workloadsByMinute: Seq[WL], n: Int): scala.Seq[WL] =
     workloadsByMinute.grouped(n).toSeq.map((g: Seq[WL]) => WL(g.head.time, g.map(_.workload).sum))
 
-  def queuesWorkloadByMinuteAsFullyPopulatedWorkloadSeq(res: Map[Long, Double]): List[Double] = {
+  def queuesWorkloadSortedByMinuteAsFullyPopulatedWorkloadSeq(res: Map[Long, Double]): List[Double] = {
     res.toSeq.sortBy(_._1).map(_._2).toList
   }
 

--- a/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
@@ -109,6 +109,7 @@ object PaxTypesAndQueues {
   val visaNationalToDesk = PaxTypeAndQueue(PaxTypes.VisaNational, Queues.NonEeaDesk)
   val nonVisaNationalToDesk = PaxTypeAndQueue(PaxTypes.NonVisaNational, Queues.NonEeaDesk)
   val visaNationalToFastTrack = PaxTypeAndQueue(PaxTypes.VisaNational, Queues.FastTrack)
+  val transitToTransfer = PaxTypeAndQueue(PaxTypes.Transit, Queues.Transfer)
   val nonVisaNationalToFastTrack = PaxTypeAndQueue(PaxTypes.NonVisaNational, Queues.FastTrack)
 
   /*todo - we should move the usages of this to airportConfig */
@@ -274,15 +275,16 @@ object AirportConfigs {
     visaNationalToDesk -> 96d / 60,
     nonVisaNationalToDesk -> 78d / 60,
     nonVisaNationalToFastTrack -> 78d / 60,
-    visaNationalToFastTrack -> 78d / 60
+    visaNationalToFastTrack -> 78d / 60,
+    transitToTransfer -> 0d
   )
   val lhr = AirportConfig(
     portCode = "LHR",
     queues = Map(
-      "T2" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack),
-      "T3" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack),
-      "T4" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack),
-      "T5" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack)
+      "T2" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack, Transfer),
+      "T3" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack, Transfer),
+      "T4" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack, Transfer),
+      "T5" -> Seq(EeaDesk, EGate, NonEeaDesk, FastTrack, Transfer)
     ),
     slaByQueue = Map(EeaDesk -> 25, EGate -> 15, NonEeaDesk -> 45, FastTrack -> 15),
     terminalNames = Seq("T2", "T3", "T4", "T5"),

--- a/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
@@ -14,6 +14,7 @@ object Queues {
   val EGate = "eGate"
   val NonEeaDesk = "nonEeaDesk"
   val FastTrack = "fastTrack"
+  val Transfer = "transfer"
 }
 
 sealed trait PaxType {
@@ -23,6 +24,8 @@ sealed trait PaxType {
 object PaxTypes {
 
   case object EeaNonMachineReadable extends PaxType
+
+  case object Transit extends PaxType
 
   case object VisaNational extends PaxType
 


### PR DESCRIPTION
This is a first cut at bring  transit passengers all the way to the UI for LHR. Have verified STN still happy. 
Intention is to cover the feature with further tests as I tackle the component redraw issues - locking them and their behaviour down with RootModel changes offers a reasonable seam. 
There's more to be done with transfer passengers calculation - all passengers that API says are transit, are considered transit. Apparently we want 10% of THEM to be added back in. But the ticket for 4602 doesn't define what we want, yet. 
