### PR TITLE
DRT-4673 & DRT-4649 Removed Terminal name from the titles of heatmaps…

### DIFF
--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -59,10 +59,11 @@ object FlightComponents {
     val port: String = if (flight.ActPax > 0) flight.ActPax.toString else "n/a"
     val last: String = flight.LastKnownPax.getOrElse("n/a").toString
     val max: String = if (flight.MaxPax > 0) flight.MaxPax.toString else "n/a"
+    val TotalPortPax: Int ={flight.ActPax}+{flight.TranPax}
 
     s"""
        |API: ${api} = (${apiIncTrans} - ${apiIncTrans - apiPax} transfer)
-       |Port: ${port} (Port transfer: ${flight.TranPax})
+       |Port: ${port} ($TotalPortPax - ${flight.TranPax} transfer)
        |Previous: ${last}
        |Max: ${max}
                   """.stripMargin

--- a/client/src/test/scala/drt/client/components/HeatmapDataTests.scala
+++ b/client/src/test/scala/drt/client/components/HeatmapDataTests.scala
@@ -27,7 +27,7 @@ HeatmapDataTests extends TestSuite {
         val terminalQueueCrunchResult = Map(queueName -> CrunchResult(0, 60000, recommendedDesks, waitTimes))
 
         val result: Pot[List[Series]] = TerminalHeatmaps.deskRecsVsActualDesks(terminalQueueCrunchResult, userDeskRecs, "T1")
-        val expected = Ready(List(Series("T1/eeaDesk", Vector(2))))
+        val expected = Ready(List(Series("eeaDesk", Vector(2))))
 
         assert(result == expected)
       }
@@ -46,7 +46,7 @@ HeatmapDataTests extends TestSuite {
 
         val recDesksRatio = 5
 
-        val expected = Ready(List(Series("T1/eeaDesk", Vector(recDesksRatio))))
+        val expected = Ready(List(Series("eeaDesk", Vector(recDesksRatio))))
 
         assert(result == expected)
       }
@@ -73,10 +73,10 @@ HeatmapDataTests extends TestSuite {
         val result: Pot[List[Series]] = TerminalHeatmaps.deskRecsVsActualDesks(terminalQueueCrunchResult, userDeskRecs, "T1")
 
         val expected = Ready(List(
-          Series("T1/nonEeaDesk",
+          Series("nonEeaDesk",
             Vector(2)
           ),
-          Series("T1/eeaDesk",
+          Series("eeaDesk",
             Vector(5)
           )
         ))
@@ -100,10 +100,10 @@ HeatmapDataTests extends TestSuite {
         val result: Pot[List[Series]] = TerminalHeatmaps.deskRecsVsActualDesks(terminalQueueCrunchResult, userDeskRecs, "T1")
 
         val expected = Ready(List(
-          Series("T1/nonEeaDesk",
+          Series("nonEeaDesk",
             Vector(6 / 3, 4 / 2)
           ),
-          Series("T1/eeaDesk",
+          Series("eeaDesk",
             Vector(10 / 2, 4 / 2)
           )
         ))

--- a/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/spatutorial/shared/HasAirportConfig.scala
@@ -10,11 +10,11 @@ import scala.collection.immutable.Seq
 
 
 object Queues {
-  val EeaDesk = "eeaDesk"
+  val EeaDesk = "EEA"
   val EGate = "eGate"
-  val NonEeaDesk = "nonEeaDesk"
-  val FastTrack = "fastTrack"
-  val Transfer = "transfer"
+  val NonEeaDesk = "Non EEA"
+  val FastTrack = "FastTrack"
+  val Transfer = "Transfer"
 }
 
 sealed trait PaxType {


### PR DESCRIPTION
… and amended pax number hover over to display in same way as API