### PR TITLE
DRT-4736 Fix crunch state actor responses

### DIFF
--- a/server/src/main/scala/actors/CrunchStateActor.scala
+++ b/server/src/main/scala/actors/CrunchStateActor.scala
@@ -114,7 +114,7 @@ class CrunchStateActor(portQueues: Map[TerminalName, Seq[QueueName]]) extends Pe
 
     state = Option(currentState.copy(
       flights = updatedFlightState(csd.flightDiffs, currentState)
-        .filter(_.apiFlight.PcpTime >= csd.crunchFirstMinuteMillis),
+        .filter(fs => (fs.apiFlight.PcpTime + 30 * oneMinute) >= csd.crunchFirstMinuteMillis),
       workloads = updatedLoadState(csd.queueDiffs, currentState),
       crunchResult = updatedCrunchState(csd.crunchFirstMinuteMillis, csd.crunchDiffs, currentState)
     ))
@@ -169,7 +169,7 @@ class CrunchStateActor(portQueues: Map[TerminalName, Seq[QueueName]]) extends Pe
     }
     val newLoads = queueLoads.foldLeft(loadByTQM) {
       case (loadsSoFar, QueueLoadDiff(tn, qn, m, pl, wl)) =>
-        if (m >= currentState.crunchFirstMinuteMillis && m < currentState.crunchFirstMinuteMillis + (1440 * oneMinute)) {
+        if (m >= currentState.crunchFirstMinuteMillis && m < currentState.crunchFirstMinuteMillis + oneDay) {
           val currentLoads = loadsSoFar.getOrElse((tn, qn, m), (0d, 0d))
           loadsSoFar.updated((tn, qn, m), (currentLoads._1 + pl, currentLoads._2 + wl))
         } else loadsSoFar

--- a/server/src/main/scala/services/Crunch.scala
+++ b/server/src/main/scala/services/Crunch.scala
@@ -140,8 +140,9 @@ object Crunch {
                                                         flightsById: Map[Int, ApiFlightWithSplits],
                                                         fsmsByFlightId: Map[Int, Set[FlightSplitMinute]],
                                                         flightSplitDiffs: Set[FlightSplitDiff]) = {
-        val flightDiffs: Set[ApiFlightWithSplits] = splitDiffsToFlightDiffs(flightsById, flightSplitDiffs)
-        flightDiffs match {
+        val flightsSinceCrunchStart: Set[ApiFlightWithSplits] = splitDiffsToFlightDiffs(flightsById, flightSplitDiffs)
+
+        flightsSinceCrunchStart match {
           case fd if fd.isEmpty => CrunchStateDiff(crunchStart, fd, Set(), Set())
           case fd => crunchStateDiffFromFlightSplitDiffs(crunchStart, crunchEnd, fsmsByFlightId, flightSplitDiffs, fd)
         }

--- a/server/src/main/scala/services/Crunch.scala
+++ b/server/src/main/scala/services/Crunch.scala
@@ -41,6 +41,7 @@ object Crunch {
   case class CrunchFlights(flights: List[ApiFlightWithSplits], crunchStart: MillisSinceEpoch, crunchEnd: MillisSinceEpoch)
 
   val oneMinute = 60000
+  val oneDay = 1440 * oneMinute
 
   trait PublisherLike {
     def publish(crunchFlights: CrunchFlights): NotUsed


### PR DESCRIPTION
 - Return only flights reaching PCP after the crunch start time
 - Return workload for only the crunch period
 - Return crunch results for only the crunch period