### PR TITLE
DRT-4845 Fix Queue ratio bug

### DIFF
--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -19,7 +19,7 @@ object FlightComponents {
     airportConfigRCP(acPot => {
       <.div(
         acPot().renderReady(ac => {
-          val paxToDisplay: Int = bestPaxToDisplay(flight, apiExTransPax, ac.portCode)
+          val paxToDisplay: Int = ArrivalHelper.bestPax(flight)
           val paxWidth = paxBarWidth(maxFlightPax, paxToDisplay)
           val paxClass = paxDisplayClass(flight, apiPax, paxToDisplay)
           val maxCapLine = maxCapacityLine(maxFlightPax, flight)

--- a/client/src/main/scala/drt/client/components/FlightsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsTable.scala
@@ -62,7 +62,7 @@ object FlightsTable {
         props.flightsWithSplitsPot.renderPending((t) => ViewTools.spinner),
         props.flightsWithSplitsPot.renderEmpty(ViewTools.spinner),
         props.flightsWithSplitsPot.renderReady(flights => {
-            FlightsWithSplitsTable.ArrivalsTable()()(FlightsWithSplitsTable.Props(flights, props.bestPax, PaxTypesAndQueues.inOrderSansFastTrack))
+            FlightsWithSplitsTable.ArrivalsTable()()(FlightsWithSplitsTable.Props(flights, PaxTypesAndQueues.inOrderSansFastTrack))
         })
       )
     }).build

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -109,7 +109,6 @@ object TerminalContentComponent {
       splitsGraphComponentColoured)(paxComp(843))
 
     def render(props: Props, state: State): TagOf[Div] = {
-      val bestPax = ArrivalHelper.bestPax _
       val queueOrder = props.airportConfig.queueOrder
 
       val desksAndQueuesActive = if (state.activeTab == "desksAndQueues") "active" else ""
@@ -161,7 +160,7 @@ object TerminalContentComponent {
                 val terminalFlights = flightsWithSplits.filter(f => f.apiFlight.Terminal == props.terminalPageTab.terminal)
                 val flightsInRange = filterFlightsByRange(props.terminalPageTab.viewMode.time, props.timeRangeHours, terminalFlights.toList)
 
-                arrivalsTableComponent(FlightsWithSplitsTable.Props(flightsInRange, bestPax, queueOrder))
+                arrivalsTableComponent(FlightsWithSplitsTable.Props(flightsInRange, queueOrder))
               }))
             } else ""
           }),

--- a/client/src/main/scala/drt/client/components/TerminalStaffing.scala
+++ b/client/src/main/scala/drt/client/components/TerminalStaffing.scala
@@ -1,7 +1,6 @@
 package drt.client.components
 
 import diode.data.Pot
-import diode.react.ModelProxy
 import drt.client.actions.Actions._
 import drt.client.services.FixedPoints._
 import drt.client.services.JSDateConversions._

--- a/client/src/test/scala/drt/client/components/FlightsTableTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightsTableTests.scala
@@ -101,7 +101,7 @@ object FlightsTableTests extends TestSuite {
                   <.td(0)))))
 
           assertRenderedComponentsAreEqual(
-            ArrivalsTable(timelineComponent = None)()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), ArrivalHelper.bestPax, PaxTypesAndQueues.inOrderSansFastTrack)),
+            ArrivalsTable(timelineComponent = None)()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), PaxTypesAndQueues.inOrderSansFastTrack)),
             staticComponent(expected)())
         }
         "ArrivalsTableComponent has a hook for a timeline column" - {
@@ -146,7 +146,7 @@ object FlightsTableTests extends TestSuite {
           //            .renderStatic(<.span("herebecallback")).build
           val timelineComponent: (Arrival) => VdomNode = (f: Arrival) => <.span("herebecallback")
           assertRenderedComponentsAreEqual(
-            ArrivalsTable(Some(timelineComponent))()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), ArrivalHelper.bestPax, PaxTypesAndQueues.inOrderSansFastTrack.toList)),
+            ArrivalsTable(Some(timelineComponent))()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), PaxTypesAndQueues.inOrderSansFastTrack.toList)),
             staticComponent(expected)())
         }
 
@@ -196,7 +196,7 @@ object FlightsTableTests extends TestSuite {
 
             val table = ArrivalsTable(timelineComponent = None,
               originMapper = (port) => originMapperComponent(port)
-            )()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), ArrivalHelper.bestPax, PaxTypesAndQueues.inOrderSansFastTrack))
+            )()(FlightsWithSplitsTable.Props(withSplits(testFlight :: Nil), PaxTypesAndQueues.inOrderSansFastTrack))
 
             assertRenderedComponentsAreEqual(table, staticComponent(expected)())
           }
@@ -270,7 +270,7 @@ object FlightsTableTests extends TestSuite {
 
           assertRenderedComponentsAreEqual(
             FlightsWithSplitsTable.ArrivalsTable(timelineComponent = None, originMapper = (s) => s)(paxComponent)(
-              FlightsWithSplitsTable.Props(withSplits(testFlightT :: Nil), ArrivalHelper.bestPax, PaxTypesAndQueues.inOrderSansFastTrack)),
+              FlightsWithSplitsTable.Props(withSplits(testFlightT :: Nil), PaxTypesAndQueues.inOrderSansFastTrack)),
             staticComponent(expected)())
 
         }

--- a/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
+++ b/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
@@ -110,6 +110,7 @@ object PaxSplitsDisplayTests extends TestSuite {
 
         assert(result == expected)
       }
+
       "Given 3 pax with a split of 1 EeaMachineReadable to Egate and 1 EeaMachineReadable to Desk then total split" +
         " all of the splits should contain whole numbers" - {
 
@@ -154,6 +155,86 @@ object PaxSplitsDisplayTests extends TestSuite {
         )
 
         assert(expected == result)
+      }
+
+      "Given a flight with all splits then I should get those splits applied as a ratio to the pax total" - {
+        val pax = 152
+        val splits = ApiSplits(
+          Set(
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "nonEeaDesk", 11.399999999999999),
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "fastTrack", 0.6),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eGate", 36.85000000000001),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "nonEeaDesk", 5.699999999999999),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eeaDesk", 30.150000000000006),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaNonMachineReadable, "eeaDesk", 15),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "fastTrack", 0.3)), "Historical", None, Percentage)
+
+
+        val expected = ApiSplits(
+          Set(
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "nonEeaDesk", 17),
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "fastTrack", 1),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eGate", 56),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "nonEeaDesk", 9),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eeaDesk", 46),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaNonMachineReadable, "eeaDesk", 23),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "fastTrack", 0)), "Historical", None, Ratio)
+
+        val result = applyPaxSplitsToFlightPax(splits, pax)
+
+        assert(result == expected)
+      }
+
+      "Given a a transfer split is included, then the split ratio should ignore the transfer queue" - {
+
+        val splits = ApiSplits(
+          Set(
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EGate, 10),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EeaDesk, 1),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.Transfer, 5)
+          ),
+          "whatevs",
+          None
+        )
+
+        val result = applyPaxSplitsToFlightPax(splits, 12)
+
+        val expected = ApiSplits(
+          Set(
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EGate, 11),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EeaDesk, 1)
+          ),
+          "whatevs",
+          None,
+          SplitStyle("Ratio")
+        )
+
+        assert(expected == result)
+      }
+
+      "Given a flight with all splits when I ask for pax per queue I should see the total broken down per queue" - {
+        val flight = ArrivalGenerator.apiFlight(1, actPax = 152)
+        val splits = ApiSplits(
+          Set(
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "nonEeaDesk", 11.399999999999999),
+            ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, "fastTrack", 0.6),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eGate", 36.85000000000001),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "nonEeaDesk", 5.699999999999999),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, "eeaDesk", 30.150000000000006),
+            ApiPaxTypeAndQueueCount(PaxTypes.EeaNonMachineReadable, "eeaDesk", 15),
+            ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, "fastTrack", 0.3)), "Historical", None, Percentage)
+
+
+        val result = FlightTableRow.paxPerQueueUsingSplitRatio(ApiFlightWithSplits(flight, Set(splits)))
+
+        val expected = Option(Map(
+          Queues.EeaDesk -> 69,
+          Queues.EGate -> 56,
+          Queues.NonEeaDesk -> 26,
+          Queues.FastTrack -> 1
+        ))
+
+        assert(result == expected)
       }
     }
   }


### PR DESCRIPTION
This change fixes a bug where transfer pax were being subtracted twice
from the PCP pax when calculating queue totals.