### PR TITLE
DRT-4934 Multi-day export ui

### DIFF
--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -6,6 +6,7 @@ import drt.client.components.{GlobalStyles, Layout, TerminalComponent, TerminalP
 import drt.client.logger._
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services._
+import drt.shared.SDateLike
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.router._
 import org.scalajs.dom
@@ -32,6 +33,10 @@ object SPAMain extends js.JSApp {
         case ("snapshot", dateStringOption) => ViewPointInTime(dateStringOption.map(SDate(_)).getOrElse(SDate.now()))
         case _ => ViewLive()
       }
+    }
+
+    def dateFromUrlOrNow: SDateLike = {
+      date.map(s => SDate(s)).getOrElse(SDate.now())
     }
 
     def updateRequired(p: TerminalPageTabLoc): Boolean = (terminal != p.terminal) || (date != p.date) || (mode != p.mode)

--- a/client/src/main/scala/drt/client/components/DateSelector.scala
+++ b/client/src/main/scala/drt/client/components/DateSelector.scala
@@ -41,7 +41,7 @@ object DateSelector {
     )
     .renderPS(r = (scope, props, state) => {
       val months = Seq("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December").zip(1 to 12)
-      val days = Seq.range(1, 32)
+      val days = 1 to 31
       val years = Seq.range(2017, today.getFullYear() + 2)
 
       def drawSelect(names: Seq[String], values: Seq[String], defaultValue: Int, callback: (String) => (State) => State) = {

--- a/client/src/main/scala/drt/client/components/DateSelector.scala
+++ b/client/src/main/scala/drt/client/components/DateSelector.scala
@@ -1,0 +1,72 @@
+package drt.client.components
+
+import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.services.JSDateConversions.SDate
+import drt.shared.SDateLike
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.vdom.TagOf
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{Callback, CallbackTo, ReactEventFromInput, ScalaComponent, _}
+import org.scalajs.dom.html.Div
+
+import scala.scalajs.js.Date
+
+object DateSelector {
+  val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  case class Props(label: String, selectedDate: SDateLike, callback: SDateLike => Callback)
+
+  case class State(day: Int, month: Int, year: Int) {
+    def selectedDate = SDate(year, month, day)
+  }
+
+  val today: SDateLike = SDate.now()
+
+  def daysInMonth(month: Int, year: Int) = new Date(year, month, 0).getDate()
+
+  def formRow(label: String, xs: TagMod*): TagOf[Div] = {
+    <.div(^.className := "form-group row",
+      <.label(label, ^.className := "col-sm-1 col-form-label"),
+      <.div(^.className := "col-sm-8", xs.toTagMod))
+  }
+
+  implicit val propsReuse: Reusability[Props] = Reusability.by(p => p.selectedDate.toISOString())
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
+
+  val component = ScalaComponent.builder[Props]("DatePicker")
+    .initialStateFromProps(
+      p => {
+        State(day = p.selectedDate.getDate(), month = p.selectedDate.getMonth(), year = p.selectedDate.getFullYear())
+      }
+    )
+    .renderPS(r = (scope, props, state) => {
+      val months = Seq("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December").zip(1 to 12)
+      val days = Seq.range(1, 32)
+      val years = Seq.range(2017, today.getFullYear() + 2)
+
+      def drawSelect(names: Seq[String], values: Seq[String], defaultValue: Int, callback: (String) => (State) => State) = {
+        <.select(^.className := "form-control", ^.value := defaultValue.toString,
+          ^.onChange ==> ((e: ReactEventFromInput) => {
+
+            scope.modState(callback(e.target.value), CallbackTo(scope.state.selectedDate) >>= props.callback)
+          }),
+          values.zip(names).map {
+            case (name, value) => <.option(^.value := value, name)
+          }.toTagMod)
+      }
+
+      <.div(^.className := "date",
+        <.div(
+          <.div(
+            formRow(s"${props.label}: ",
+            <.div(^.className := "day date-field", drawSelect(names = List.range(1, daysInMonth(state.month, state.year) + 1).map(_.toString), values = days.map(_.toString), defaultValue = state.day, callback = (v: String) => (s: State) => s.copy(day = v.toInt))),
+            <.div(^.className := "month date-field", drawSelect(names = months.map(_._2.toString), values = months.map(_._1.toString), defaultValue = state.month, callback = (v: String) => (s: State) => s.copy(month = v.toInt))),
+            <.div(^.className := "year date-field", drawSelect(names = years.map(_.toString), values = years.map(_.toString), defaultValue = state.year, callback = (v: String) => (s: State) => s.copy(year = v.toInt)))
+          ))
+        ))
+    })
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(label: String, selectedDate: SDateLike, callback: SDateLike => Callback): VdomElement = component(Props(label, selectedDate, callback))
+}

--- a/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
+++ b/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
@@ -1,0 +1,106 @@
+package drt.client.components
+
+import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.services.JSDateConversions.SDate
+import drt.shared.SDateLike
+import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.vdom.html_<^._
+import org.scalajs.dom
+
+object MultiDayExportComponent {
+  val today: SDateLike = SDate.now()
+  val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  case class Props(
+                    terminal: String,
+                    selectedDate: SDateLike
+                  )
+
+  case class State(startDay: Int,
+                   startMonth: Int,
+                   startYear: Int,
+                   endDay: Int,
+                   endMonth: Int,
+                   endYear: Int,
+                   showDialogue: Boolean = false
+                  ) {
+    def startMillis = SDate(startYear, startMonth, startDay).millisSinceEpoch
+
+    def endMillis = SDate(endYear, endMonth, endDay).millisSinceEpoch
+  }
+
+  implicit val stateReuse: Reusability[State] = Reusability.derive[State]
+  implicit val propsReuse: Reusability[Props] = Reusability.by(p => (p.terminal, p.selectedDate.millisSinceEpoch))
+
+  val component = ScalaComponent.builder[Props]("SnapshotSelector")
+    .initialStateFromProps(p => State(
+      startDay = p.selectedDate.getDate(),
+      startMonth = p.selectedDate.getMonth(),
+      startYear = p.selectedDate.getFullYear(),
+      endDay = p.selectedDate.getDate(),
+      endMonth = p.selectedDate.getMonth(),
+      endYear = p.selectedDate.getFullYear()
+    ))
+    .renderPS((scope, props, state) => {
+
+      val showClass = if (state.showDialogue) "show" else "fade"
+
+      <.div(
+        <.a(
+          "Multi Day Export",
+          ^.className := "btn btn-default",
+          VdomAttr("data-toggle") := "modal",
+          VdomAttr("data-target") := "#multi-day-export",
+          ^.onClick --> scope.modState(_.copy(showDialogue = true))
+        ),
+        <.div(^.className := "multi-day-export modal " + showClass, ^.id := "#multi-day-export", ^.tabIndex := -1, ^.role := "dialog",
+          <.div(
+            ^.className := "modal-dialog modal-dialog-centered",
+            ^.role := "document",
+            <.div(
+              ^.className := "modal-content",
+              <.div(
+                ^.className := "modal-header",
+                <.h5(^.className := "modal-title", "Choose what to export")
+              ),
+              <.div(
+                ^.className := "modal-body",
+                DateSelector("From", today, d => {
+                  log.info(s"From: Got this date from callback: $d")
+                  scope.modState(_.copy(startDay = d.getDate(), startMonth = d.getMonth(), startYear = d.getFullYear()))
+                }),
+                DateSelector("To", today, d => {
+                  log.info(s"To: Got this date from callback: $d")
+                  scope.modState(_.copy(endDay = d.getDate(), endMonth = d.getMonth(), endYear = d.getFullYear()))
+                }),
+                <.div(
+                  <.div(^.className := "multi-day-export-links",
+                    <.a("Export Arrivals",
+                      ^.className := "btn btn-default",
+                      ^.href := s"${dom.window.location.pathname}/export/arrivals/${state.startMillis}/${state.endMillis}/${props.terminal}",
+                      ^.target := "_blank"),
+                    <.a("Export Desks",
+                      ^.className := "btn btn-default",
+                      ^.href := s"${dom.window.location.pathname}/export/desks/${state.startMillis}/${state.endMillis}/${props.terminal}",
+                      ^.target := "_blank")
+                  )
+                )
+              ),
+              <.div(
+                ^.className := "modal-footer",
+                <.button(
+                  ^.className := "btn btn-link",
+                  VdomAttr("data-dismiss") := "modal", "Close",
+                  ^.onClick --> scope.modState(_.copy(showDialogue = false))
+                )
+              )
+            )
+          )
+        ))
+    })
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(terminal: String, selectedDate: SDateLike): VdomElement = component(Props(terminal, selectedDate))
+}

--- a/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
+++ b/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
@@ -67,11 +67,9 @@ object MultiDayExportComponent {
               <.div(
                 ^.className := "modal-body",
                 DateSelector("From", today, d => {
-                  log.info(s"From: Got this date from callback: $d")
                   scope.modState(_.copy(startDay = d.getDate(), startMonth = d.getMonth(), startYear = d.getFullYear()))
                 }),
                 DateSelector("To", today, d => {
-                  log.info(s"To: Got this date from callback: $d")
                   scope.modState(_.copy(endDay = d.getDate(), endMonth = d.getMonth(), endYear = d.getFullYear()))
                 }),
                 <.div(

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -7,13 +7,13 @@ import drt.client.components.FlightComponents.SplitsGraph.splitsGraphComponentCo
 import drt.client.components.FlightComponents.paxComp
 import drt.client.logger.log
 import drt.client.services.JSDateConversions.SDate
-import drt.client.services.{CurrentWindow, SPACircuit, TimeRangeHours, ViewMode}
+import drt.client.services.{SPACircuit, TimeRangeHours, ViewMode}
 import drt.shared.CrunchApi.{CrunchState, MillisSinceEpoch}
 import drt.shared._
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
-import japgolly.scalajs.react.vdom.{TagOf, html_<^}
 import japgolly.scalajs.react.vdom.html_<^.{<, VdomAttr, VdomElement, ^, vdomElementFromComponent, vdomElementFromTag, _}
+import japgolly.scalajs.react.vdom.{TagOf, html_<^}
 import japgolly.scalajs.react.{BackendScope, Callback, ScalaComponent}
 import org.scalajs.dom
 import org.scalajs.dom.html.Div
@@ -60,7 +60,7 @@ object TerminalContentComponent {
     }
   }
 
-  case class State(activeTab: String)
+  case class State(activeTab: String, showExportDialogue: Boolean = false)
 
   implicit val propsReuse: Reusability[Props] = Reusability.by((_: Props).hash)
   implicit val stateReuse: Reusability[State] = Reusability.derive[State]
@@ -141,7 +141,8 @@ object TerminalContentComponent {
           ),
           <.div(^.className := "exports",
             <.a("Export Arrivals", ^.className := "btn btn-default", ^.href := s"${dom.window.location.pathname}/export/arrivals/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${props.timeRangeHours.start}&endHour=${props.timeRangeHours.end}", ^.target := "_blank"),
-            <.a("Export Desks", ^.className := "btn btn-default", ^.href := s"${dom.window.location.pathname}/export/desks/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${props.timeRangeHours.start}&endHour=${props.timeRangeHours.end}", ^.target := "_blank")
+            <.a("Export Desks", ^.className := "btn btn-default", ^.href := s"${dom.window.location.pathname}/export/desks/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${props.timeRangeHours.start}&endHour=${props.timeRangeHours.end}", ^.target := "_blank"),
+            MultiDayExportComponent(props.terminalPageTab.terminal, props.terminalPageTab.dateFromUrlOrNow)
           )
         ),
         <.div(^.className := "tab-content",
@@ -179,7 +180,8 @@ object TerminalContentComponent {
               log.info(s"Rendering staffing $state")
               TerminalStaffing(TerminalStaffing.Props(props.terminalPageTab.terminal, props.potShifts, props.potFixedPoints, props.potStaffMovements, props.airportConfig))
             } else ""
-          )))
+          ))
+      )
     }
   }
 

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -130,6 +130,40 @@
   position: relative;
 }
 
+.modal-header {
+  text-align: left;
+}
+.modal-footer {
+  padding: 6px;
+}
+.multi-day-export-links {
+  text-align: left;
+  margin-left: 59px;
+}
+
+.multi-day-export .modal-content {
+  margin-top: 200px;
+}
+
+.date .form-group.row .date-field {
+  float: left;
+}
+
+.date .form-group.row .col-form-label{
+  margin-top: 7px;
+  margin-left: 10px;
+}
+
+.date .form-group.row .day {
+  width: 50px;
+}
+.date .form-group.row .month {
+  width: 100px;
+}
+.date .form-group.row .year {
+  width: 60px;
+}
+
 .date-view-picker-container {
   display: flex;
   padding: 10px 17px 0 0;


### PR DESCRIPTION
 Adds a link to export multiple days for desks and queues.

  - New link on current/snapshot pages to do the exports
  - modal dialog to choose date range to export
  - new date picker component