### PR TITLE
DRT-4994 Fix monthly staffing

### DIFF
--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -46,7 +46,7 @@ object SPAMain extends js.JSApp {
         GetForecastWeek(TerminalPlanningComponent.defaultStartDate(date), terminal)
       case "staffing" =>
         log.info(s"dispatching get shifts for month on staffing page")
-        GetShiftsForMonth(TerminalStaffingV2.dateFromDateStringOption(date))
+        GetShiftsForMonth(TerminalStaffingV2.dateFromDateStringOption(date), terminal)
       case _ => SetViewMode(viewMode)
     }
   }

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -62,7 +62,7 @@ object Actions {
 
   case class SetShiftsForMonth(shiftsForMonth: MonthOfRawShifts) extends Action
 
-  case class GetShiftsForMonth(month: SDateLike) extends Action
+  case class GetShiftsForMonth(month: SDateLike, terminalName: TerminalName) extends Action
 
   case class AddShift(shift: StaffAssignment) extends Action
 

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -331,15 +331,15 @@ class ShiftsForMonthHandler[M](modelRW: ModelRW[M, Pot[MonthOfRawShifts]]) exten
         }
       effectOnly(Effect(action))
 
-    case GetShiftsForMonth(month) =>
+    case GetShiftsForMonth(month, terminalName) =>
       log.info(s"Calling getShifts for Month")
 
-      val apiCallEffect = Effect(AjaxClient[Api].getShiftsForMonth(month.millisSinceEpoch).call()
+      val apiCallEffect = Effect(AjaxClient[Api].getShiftsForMonth(month.millisSinceEpoch, terminalName).call()
         .map(s => SetShiftsForMonth(MonthOfRawShifts(month.millisSinceEpoch, s)))
         .recoverWith {
-          case _ =>
-            log.error(s"Failed to get shifts. Re-requesting after ${PollDelay.recoveryDelay}")
-            Future(RetryActionAfter(GetShiftsForMonth(month), PollDelay.recoveryDelay))
+          case t =>
+            log.error(s"Failed to get shifts. Re-requesting after ${PollDelay.recoveryDelay}: $t")
+            Future(RetryActionAfter(GetShiftsForMonth(month, terminalName), PollDelay.recoveryDelay))
         })
       updated(Pending(), apiCallEffect)
     case SetShiftsForMonth(monthOfRawShifts) =>

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -454,13 +454,13 @@ class Application @Inject()(implicit val config: Configuration,
         } else throw new Exception("You do not have permission to edit staffing.")
       }
 
-      def getShiftsForMonth(month: MillisSinceEpoch): Future[String] = {
+      def getShiftsForMonth(month: MillisSinceEpoch, terminalName: TerminalName): Future[String] = {
         val shiftsFuture = shiftsActor ? GetState
 
         shiftsFuture.collect {
           case shifts: String =>
             log.info(s"Shifts: Retrieved shifts from actor")
-            StaffTimeSlots.getShiftsForMonth(shifts, SDate(month))
+            StaffTimeSlots.getShiftsForMonth(shifts, SDate(month), terminalName)
         }
       }
 

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -96,7 +96,7 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def saveStaffTimeSlotsForMonth(timeSlotsForMonth: StaffTimeSlotsForTerminalMonth): Future[Unit]
 
-  def getShiftsForMonth(month: MillisSinceEpoch): Future[String]
+  def getShiftsForMonth(month: MillisSinceEpoch, terminalName: TerminalName): Future[String]
 
   def isLoggedIn(): Boolean
 }

--- a/server/src/test/scala/services/shifts/StaffTimeSlotsSpec.scala
+++ b/server/src/test/scala/services/shifts/StaffTimeSlotsSpec.scala
@@ -193,7 +193,7 @@ class StaffTimeSlotsSpec extends Specification {
 
       val expected = ""
 
-      val result = getShiftsForMonth(shifts, month)
+      val result = getShiftsForMonth(shifts, month, "T1")
 
       result === expected
     }
@@ -207,10 +207,10 @@ class StaffTimeSlotsSpec extends Specification {
 
       val expected =
         """
-          |shift0120180, T1, 05/01/18, 00:00, 00:14, 10
+          |0,T1,05/01/18,00:00,00:14,10
         """.stripMargin.trim
 
-      val result = getShiftsForMonth(shifts, month)
+      val result = getShiftsForMonth(shifts, month, "T1")
 
       result === expected
     }
@@ -225,10 +225,10 @@ class StaffTimeSlotsSpec extends Specification {
 
       val expected =
         """
-          |shift0120180, T1, 05/01/18, 00:00, 00:14, 10
+          |0,T1,05/01/18,00:00,00:14,10
         """.stripMargin.trim
 
-      val result = getShiftsForMonth(shifts, month)
+      val result = getShiftsForMonth(shifts, month, "T1")
 
       result === expected
     }

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -465,7 +465,7 @@ trait Api {
 
   def saveStaffTimeSlotsForMonth(timeSlotsForMonth: StaffTimeSlotsForTerminalMonth): Future[Unit]
 
-  def getShiftsForMonth(month: MillisSinceEpoch): Future[String]
+  def getShiftsForMonth(month: MillisSinceEpoch, terminalName: TerminalName): Future[String]
 
   def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]]
 


### PR DESCRIPTION
- Reduce shift names and remove whitespace from shift lines
- Convert first milli of month into europe/london timezone before removing existing shifts for the month